### PR TITLE
docs : 학습 문서 이관

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
 - 2020-03-10 [객체지향의 TDA : Tell Don't ASK](./personal/2020-03-10_tell-don-t-ask.md)
 - 2022-01-15 [ddd with pivotal : 은행 시스템으로 살펴보는 DDD 약식](./development/2022-01-15_ddd-with-pivotal.md)
 - 2024-04-10 [세미나: 잘 키운 모노리스 하나 열 마이크로서비스 안부럽다](./dummy/2024-04-10_wellgrown-monolith.md)
+- 2026-04-12 [DDD 계층 구조와 DIP 적용 실습](./development/2026-04-12_ddd-layered-architecture-dip-order-practice.md)
 
 ## Backend & Spring
 
@@ -68,6 +69,11 @@
 - 2024-01-20 [spring 로컬캐시 사용기](./dummy/2024-01-20_spring-cache.md)
 - 2024-05-06 [spring @Transactional propagation & proxy](./dummy/2024-05-06_spring-transactional-propagation-and-proxy.md)
 - 2024-11-25 [spring jpa 에서 strategy = GenerationType.IDENTITY 로 최초 생성 시 에러가 발생하면?](./dummy/2024-11-25_jpa-strategy-identity-error.md)
+- 2026-03-22 [Caffeine Local Cache 딥다이브](./dummy/2026-03-22_caffeine-local-cache-deep-dive.md)
+- 2026-03-22 [Caffeine 내부구조 심화](./dummy/2026-03-22_caffeine-local-cache-internals-deep-dive.md)
+- 2026-03-24 [RequestContextHolder 실전 가이드](./dummy/2026-03-24_request-context-holder-practice.md)
+- 2026-04-12 [Eventual Consistency 실습](./dummy/2026-04-12_eventual-consistency-review-summary-practice.md)
+- 2026-04-13 [Caffeine Local Cache 활용 패턴 정리](./dummy/2026-04-13_caffeine-local-cache-patterns.md)
 
 ### Spring Boot & Backend Notes
 
@@ -134,6 +140,7 @@
 - 2022-07-06 [resources.requests & resources.limits](./infra/k8s/2022-07-06_know-resources-requests-and-resources-limits.md)
 - 2024-03-23 [kubernetes, k8s openlens](./infra/k8s/2024-03-23_open-lens.md)
 - 2025-08-21 [k8s probe 설정](./dummy/2025-08-21_k8s-probe.md)
+- 2026-03-24 [K8s 다중 파드에서 Local Cache 운영 패턴](./infra/k8s/2026-03-24_k8s-local-cache-patterns.md)
 
 ### Monitoring
 

--- a/development/2026-04-12_ddd-layered-architecture-dip-order-practice.md
+++ b/development/2026-04-12_ddd-layered-architecture-dip-order-practice.md
@@ -29,6 +29,99 @@
 
 ## 동작 방식
 
+### 0) 핵심 코드 먼저 보기
+
+응용 서비스는 유스케이스 흐름을 조율한다. 커맨드를 도메인 객체로 바꾸고, 저장소를 통해 애그리거트를 저장/조회하지만, “취소된 주문은 배송지를 바꿀 수 없다” 같은 규칙은 직접 구현하지 않는다.
+
+```kotlin
+@Service
+class StudyOrderService(
+    private val orderRepository: OrderRepository,
+) : PlaceOrderUseCase, ChangeShippingInfoUseCase {
+
+    @Transactional
+    override fun placeOrder(command: PlaceOrderCommand): Order =
+        command.toDomainOrder().also(orderRepository::save)
+
+    @Transactional
+    override fun changeShippingInfo(command: ChangeShippingInfoCommand): Order {
+        val orderId = command.orderId.toDomainOrderId()
+        val order = orderRepository.findById(orderId)
+            ?: throw OrderNotFoundException(orderId)
+
+        order.changeShippingInfo(command.toDomainShippingInfo())
+        return order.also(orderRepository::save)
+    }
+}
+```
+
+도메인 규칙은 애그리거트 루트인 `Order`에 둔다. 생성 시점 검증은 `create`, 상태 변경 검증은 도메인 메서드가 맡는다.
+
+```kotlin
+class Order private constructor(
+    val id: OrderId,
+    val orderer: Orderer,
+    val orderLines: List<OrderLine>,
+    shippingInfo: ShippingInfo,
+    val totalAmount: Money,
+    val createdAt: Instant,
+) {
+    var shippingInfo: ShippingInfo = shippingInfo
+        private set
+
+    var status: OrderStatus = OrderStatus.CREATED
+        private set
+
+    fun changeShippingInfo(newShippingInfo: ShippingInfo) {
+        ensureNotCanceled()
+        shippingInfo = newShippingInfo
+    }
+
+    fun cancel(canceledTime: Instant = Instant.now()) {
+        ensureNotCanceled()
+        status = OrderStatus.CANCELED
+    }
+
+    private fun ensureNotCanceled() {
+        if (status == OrderStatus.CANCELED) {
+            throw InvalidOrderStateException("취소된 주문은 수정할 수 없습니다.")
+        }
+    }
+
+    companion object {
+        fun create(
+            id: OrderId,
+            orderer: Orderer,
+            orderLines: List<OrderLine>,
+            shippingInfo: ShippingInfo,
+            createdAt: Instant = Instant.now(),
+        ): Order {
+            if (orderLines.isEmpty()) {
+                throw InvalidOrderException("주문 항목은 최소 1개 이상이어야 합니다.")
+            }
+
+            val immutableLines = orderLines.toList()
+            val total = immutableLines.fold(Money.zero()) { acc, line ->
+                acc.plus(line.totalPrice())
+            }
+
+            return Order(id, orderer, immutableLines, shippingInfo, total, createdAt)
+        }
+    }
+}
+```
+
+저장소는 응용 계층이 의존하는 인터페이스다. 인메모리/JPA 같은 구현 기술은 이 인터페이스 뒤로 숨는다.
+
+```kotlin
+interface OrderRepository {
+    fun save(order: Order)
+    fun findById(orderId: OrderId): Order?
+}
+```
+
+아래 다이어그램들은 이 코드 구조를 다른 관점으로 펼쳐 본 것이다. `StudyOrderService`는 응용 계층, `Order`는 도메인 계층, `OrderRepository` 구현체는 인프라 계층에 대응된다.
+
 ### 1) 도메인 모델과 엔티티 관계
 
 ```mermaid
@@ -244,7 +337,7 @@ flowchart LR
 - 결제/재고/이벤트 발행도 인터페이스 기반으로 분리하면 DIP를 유지한 채 확장할 수 있다.
 - 저장 구조 설계는 도메인 모델 확정 이후에 조회/성능 요구를 반영해 조정한다.
 - 리뷰 요약처럼 애그리거트 간 조회 요구는 eventual consistency 리드모델로 해결할 수 있다.
-  - 참고: `study/2026-04-12_eventual-consistency-review-summary-practice.md`
+  - 참고: [Eventual Consistency 실습](../dummy/2026-04-12_eventual-consistency-review-summary-practice.md)
 
 ## 유의사항
 

--- a/development/2026-04-12_ddd-layered-architecture-dip-order-practice.md
+++ b/development/2026-04-12_ddd-layered-architecture-dip-order-practice.md
@@ -1,0 +1,254 @@
+# DDD 계층 구조와 DIP 적용 실습 (주문 예제)
+
+## 요약
+
+이번 실습은 다음 관점을 코드에 녹이는 데 집중했다.
+
+- 도메인 모델은 엔티티와 같은 개념이 아니다.
+- 엔티티는 도메인 모델의 구성요소 중 하나다.
+- 응용 계층은 유스케이스를 조율하고, 도메인 계층은 규칙을 책임진다.
+- 인프라 계층은 저장/외부 연동 같은 구현 기술을 담당한다.
+- DIP는 유지하되, 헥사고날 아키텍처 용어(`Port`, `Adapter`)는 사용하지 않는다.
+- 도메인 구성요소로 분류/상품/리뷰/주문/결제/회원/배송 추적 모델을 함께 다룬다.
+
+핵심은 "비즈니스 규칙을 DB 구조가 아니라 도메인 모델 중심으로 표현하는 것"이다.
+
+## 사용법
+
+1. 주문 생성
+
+- `PlaceOrderUseCase.placeOrder(command)`를 호출한다.
+- 응용 서비스는 커맨드를 도메인 객체로 변환하고 `Order.create(...)`를 호출한다.
+- 생성 검증은 도메인 밸류 객체와 애그리거트가 처리한다.
+
+2. 배송 정보 변경
+
+- `ChangeShippingInfoUseCase.changeShippingInfo(command)`를 호출한다.
+- 응용 서비스는 `OrderRepository`로 주문을 조회하고 `Order.changeShippingInfo(...)`를 호출한다.
+- 취소된 주문 변경 금지 같은 규칙은 `Order`가 강제한다.
+
+## 동작 방식
+
+### 1) 도메인 모델과 엔티티 관계
+
+```mermaid
+flowchart LR
+  DM[도메인 모델] --> E[엔티티: Order]
+  DM --> V[밸류 객체]
+  DM --> A[애그리거트]
+  DM --> DS[도메인 서비스]
+
+  V --> OID[OrderId]
+  V --> MID[MemberId]
+  V --> PID[ProductId]
+  V --> M[Money]
+  V --> OA[Orderer]
+  V --> OL[OrderLine]
+  V --> SI[ShippingInfo]
+  V --> RV[Receiver]
+  V --> AD[Address]
+
+  A --> AR[Aggregate Root: Order]
+```
+
+### 2) 계층 책임 분리
+
+```mermaid
+flowchart LR
+  subgraph APP[응용 계층]
+    U1[PlaceOrderUseCase]
+    U2[ChangeShippingInfoUseCase]
+    S[StudyOrderService]
+    R[OrderRepository interface]
+    U1 --> S
+    U2 --> S
+    S --> R
+  end
+
+  subgraph DOMAIN[도메인 계층]
+    O[Order Aggregate]
+    VO[Value Objects]
+    S --> O
+    S --> VO
+  end
+
+  subgraph INFRA[인프라 계층]
+    IMPL[InMemoryOrderRepository]
+    R --> IMPL
+  end
+```
+
+### 3) 주문 처리 흐름
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant App as StudyOrderService
+  participant Mapper as OrderCommandMapper
+  participant Domain as Order
+  participant Repo as OrderRepository
+  participant Infra as InMemoryOrderRepository
+
+  Client->>App: placeOrder(command)
+  App->>Mapper: command -> domain values
+  App->>Domain: Order.create(...)
+  Domain-->>App: Order
+  App->>Repo: save(order)
+  Repo->>Infra: persist
+  App-->>Client: Order
+
+  Client->>App: changeShippingInfo(command)
+  App->>Repo: findById(orderId)
+  Repo->>Infra: load
+  Infra-->>Repo: Order
+  Repo-->>App: Order
+  App->>Domain: order.changeShippingInfo(...)
+  App->>Repo: save(order)
+  App-->>Client: Order
+```
+
+### 4) 도메인 엔티티와 저장 구조의 관계
+
+```mermaid
+flowchart LR
+  D[도메인 엔티티/밸류] <-- 매핑 --> S[저장 구조]
+  D -->|비즈니스 의미/규칙 중심| B[도메인 모델링]
+  S -->|조회/저장/정규화/성능 중심| DB[RDB 스키마 설계]
+
+  N[핵심: 도메인 엔티티와 테이블은 1:1 강제가 아니다]
+  B -.-> N
+  DB -.-> N
+```
+
+### 5) 아키텍처 선택 기준
+
+- 이 예제는 헥사고날 아키텍처를 채택하지 않는다.
+- `Port`, `Adapter` 용어는 지양하고 `Repository interface/구현체` 용어로 단순화했다.
+- 이유는 학습 단계에서 용어/구조 복잡도를 낮추고, 계층 책임과 도메인 규칙에 집중하기 위해서다.
+
+### 6) 애그리거트 경계 판단 기준
+
+- "A가 B를 가진다"는 표현만으로 같은 애그리거트라고 판단하지 않는다.
+- 생성 시점, 변경 주기, 즉시 일관성 규칙이 다르면 애그리거트를 분리한다.
+- 경계 간 참조는 객체 참조 대신 식별자 참조를 우선한다.
+
+```mermaid
+flowchart LR
+  subgraph Catalog["카탈로그 경계"]
+    C[Category]
+    P[Product]
+  end
+
+  subgraph ReviewBoundary["리뷰 경계"]
+    R[Review]
+  end
+
+  subgraph OrderBoundary["주문 경계"]
+    O[Order]
+    OL[OrderLine]
+    SI[ShippingInfo]
+    PI[PaymentInfo]
+  end
+
+  subgraph MemberBoundary["회원 경계"]
+    M[Member]
+  end
+
+  subgraph DeliveryBoundary["배송추적 경계"]
+    D[DeliveryTracking]
+  end
+
+  P -->|productId| R
+  O -->|memberId snapshot| M
+  D -->|orderId| O
+```
+
+### 7) 트랜잭션 경계 원칙
+
+- 트랜잭션 범위는 작을수록 좋다.
+- 기본 원칙은 유스케이스 1개가 애그리거트 1개를 변경하도록 설계하는 것이다.
+- 여러 애그리거트를 한 트랜잭션에서 함께 수정하면 락 보유 시간/충돌/성능 비용이 커질 수 있다.
+- 본 예제도 응용 서비스 메서드 단위로 `@Transactional`을 두고, 애그리거트 루트 도메인 메서드만 호출하도록 구성했다.
+
+### 8) 바운디드 컨텍스트 관점으로 본 주문 모듈
+
+- 바운디드 컨텍스트는 도메인 모델만의 경계가 아니다.
+- 주문 컨텍스트는 API, 응용 서비스, 도메인 모델, 인프라 구현, 저장 구조를 함께 포함하는 실행 단위다.
+- 학습 난이도와 결합도를 낮추기 위해 주문 예제를 컨텍스트별 패키지로 분리했다.
+  - `ordering`: 주문 생성/배송지 변경
+  - `catalog`: 카테고리/상품
+  - `review`: 리뷰/리뷰 요약 리드모델
+  - `member`: 회원/등급
+  - `shipping`: 배송 추적
+  - `shared`: 컨텍스트 간 공유 식별자/공통 예외
+
+```mermaid
+flowchart LR
+  subgraph OrderingBC["Ordering BC"]
+    API["API: study/ddd/ordering/api"]
+    APP["Application: study/ddd/ordering/application"]
+    DOMAIN["Domain: study/ddd/ordering/domain"]
+    INFRA["Infra: study/ddd/ordering/infra"]
+    API --> APP --> DOMAIN
+    APP --> INFRA
+  end
+
+  subgraph CatalogBC["Catalog BC"]
+    CAPP["Application: study/ddd/catalog/application"]
+    CDOMAIN["Domain: study/ddd/catalog/domain"]
+    CINFRA["Infra: study/ddd/catalog/infra"]
+    CAPP --> CDOMAIN
+    CAPP --> CINFRA
+  end
+
+  subgraph ReviewBC["Review BC"]
+    RAPP["Application: study/ddd/review/application"]
+    RDOMAIN["Domain: study/ddd/review/domain"]
+    RINFRA["Infra: study/ddd/review/infra"]
+    RAPP --> RDOMAIN
+    RAPP --> RINFRA
+  end
+
+  subgraph SharedKernel["Shared"]
+    SHARED["study/ddd/shared"]
+  end
+
+  DOMAIN -. 식별자 참조 .-> SHARED
+  CDOMAIN -. 식별자 참조 .-> SHARED
+  RDOMAIN -. 식별자 참조 .-> SHARED
+```
+
+- 같은 용어라도 컨텍스트가 다르면 의미가 달라질 수 있다.
+  - 판매 컨텍스트의 상품: 판매 가능한 상품
+  - 배송 컨텍스트의 상품: 배송 대상 품목
+  - 정산 컨텍스트의 상품: 정산 기준 항목
+
+### 9) Kotlin `@JvmInline value class`를 DDD에 쓰는 이유와 방법
+
+- 왜 쓰는가
+  - 식별자/점수 같은 도메인 값을 원시 타입(`String`, `Int`) 대신 의미 있는 타입으로 표현해 타입 안정성을 높인다.
+  - `OrderId`, `MemberId`, `ProductId`를 서로 잘못 전달하는 실수를 컴파일 단계에서 줄인다.
+  - 생성 팩토리(`of`)에서 검증을 강제해 "유효한 상태로 생성" 원칙을 지키기 쉽다.
+- 어떻게 쓰는가
+  - 단일 값 래퍼를 `@JvmInline value class`로 선언한다.
+  - 주 생성자는 `private`으로 숨기고 `companion object`의 `of(...)`로만 생성하게 한다.
+  - 예시: `OrderId`, `MemberId`, `ProductId`, `CategoryId`, `ReviewId`, `ReviewScore`.
+- 유의사항
+  - 제네릭/널 처리/인터페이스 업캐스팅 같은 상황에서는 boxing이 발생할 수 있다.
+  - JPA 엔티티 필드에 바로 매핑할 때는 `AttributeConverter` 같은 매핑 전략을 함께 설계한다.
+  - 남용보다는 "도메인 의미가 분명한 값"에 우선 적용한다.
+
+## 응용
+
+- 인메모리 저장소 대신 JPA 기반 `OrderRepository` 구현체를 추가해도 응용/도메인 코드는 유지할 수 있다.
+- 결제/재고/이벤트 발행도 인터페이스 기반으로 분리하면 DIP를 유지한 채 확장할 수 있다.
+- 저장 구조 설계는 도메인 모델 확정 이후에 조회/성능 요구를 반영해 조정한다.
+- 리뷰 요약처럼 애그리거트 간 조회 요구는 eventual consistency 리드모델로 해결할 수 있다.
+  - 참고: `study/2026-04-12_eventual-consistency-review-summary-practice.md`
+
+## 유의사항
+
+- 유효성 검증이 응용 서비스로 새어 나오면 도메인 규칙이 분산된다.
+- 도메인 타입(`OrderId`, `MemberId`, `ProductId`)을 다시 원시값으로 되돌리면 타입 안정성이 약해진다.
+- 도메인 모델을 테이블 구조에 맞춰 먼저 설계하면 비즈니스 규칙 표현력이 떨어질 수 있다.
+- 학습 예제에서는 단순화를 위해 트랜잭션/락/동시성 전략을 최소화했다.

--- a/dummy/2026-03-22_caffeine-local-cache-deep-dive.md
+++ b/dummy/2026-03-22_caffeine-local-cache-deep-dive.md
@@ -1,0 +1,424 @@
+# Caffeine Local Cache 딥다이브
+
+Spring Boot에서 Caffeine을 사용할 때는 적용 방식의 선택 기준을 먼저 정리해야 한다.
+
+> 선택 기준: `@Cacheable` + `CaffeineCacheManager` 중심의 선언형 적용 vs native Caffeine API 기반의 직접 제어
+
+이 문서는 다음 4축으로 정리한다.
+- 사용방법
+- 동작방식
+- 응용방식
+- 유의사항(사이드 이펙트)
+
+그리고 내부 구현은 별도 심화 문서로 분리했다.
+- 심화: [Caffeine 내부구조 심화 문서](./2026-03-22_caffeine-local-cache-internals-deep-dive.md)
+
+---
+
+## TL;DR
+- Caffeine은 단순 Map이 아니라 **축출 정책 + 동시성 최적화 + 높은 hit ratio**를 목표로 설계된 캐시다.
+- Spring 래핑 방식도 충분히 강력하다. 다만 응답에 source/TTL을 노출하거나 L1/L2 흐름을 세밀하게 제어하려면 native 방식이 더 명확할 수 있다.
+- 캐시 품질은 "라이브러리 선택"보다 "TTL/키/무효화/관측성 설계"가 좌우한다.
+
+---
+
+## 1) 사용방법
+
+### 1-1. 의존성
+
+```kotlin
+implementation("org.springframework.boot:spring-boot-starter-cache")
+implementation("com.github.ben-manes.caffeine:caffeine")
+```
+
+### 1-2. 최소 설정 (Spring Bean)
+
+```kotlin
+@Bean
+fun localCache(
+    @Value("\${study.cache.local-ttl-seconds:10}") ttlSeconds: Long,
+): Cache<String, Product> {
+    return Caffeine.newBuilder()
+        // write 이후 ttlSeconds가 지나면 만료
+        .expireAfterWrite(Duration.ofSeconds(ttlSeconds))
+        // 최대 엔트리 수 제한
+        .maximumSize(10_000)
+        // 통계 수집 활성화 (Micrometer 연결 시 유용)
+        .recordStats()
+        .build()
+}
+```
+
+### 1-3. LoadingCache / AsyncLoadingCache 예시
+
+```kotlin
+// miss 시 loader를 통해 자동 적재
+val loadingCache = Caffeine.newBuilder()
+    .maximumSize(10_000)
+    .expireAfterWrite(Duration.ofMinutes(5))
+    .build<String, Product> { key ->
+        // loader 내부는 느린 IO(DB/API) 가능
+        productRepository.findById(key)
+            ?: error("not found: $key")
+    }
+
+// 비동기 로딩 버전 (CompletableFuture)
+val asyncCache = Caffeine.newBuilder()
+    .maximumSize(10_000)
+    .buildAsync<String, Product> { key, _ ->
+        CompletableFuture.supplyAsync {
+            productRepository.findById(key)
+                ?: error("not found: $key")
+        }
+    }
+```
+
+### 1-4. API 선택 기준 (표)
+
+| API | 추천 상황 | 장점 | 유의사항 |
+| --- | --- | --- | --- |
+| `Cache<K, V>` | cache-aside를 서비스 코드에서 직접 제어할 때 | 제어점이 가장 많음 | miss 로딩/중복 요청 방지 로직을 직접 설계해야 함 |
+| `LoadingCache<K, V>` | miss 로딩 규칙이 명확할 때 | 코드 간결, 자동 로딩 | loader 실패/지연 시 영향 범위를 설계해야 함 |
+| `AsyncLoadingCache<K, V>` | 로딩 지연이 크고 비동기 처리가 필요할 때 | 스레드 점유 감소, 병렬 처리 유리 | Future 체인/타임아웃/예외 처리 설계 필요 |
+
+### 1-5. Spring 래핑 사용 예시
+
+```kotlin
+@Bean
+fun cacheManager(): CacheManager {
+    val manager = CaffeineCacheManager("products")
+    manager.setCaffeine(
+        Caffeine.newBuilder()
+            .maximumSize(10_000)
+            .expireAfterWrite(Duration.ofSeconds(10))
+    )
+    return manager
+}
+
+@Cacheable(cacheNames = ["products"], key = "#id")
+fun findProduct(id: String): Product {
+    return productRepository.findById(id)
+        ?: error("not found")
+}
+```
+
+출처:
+- Caffeine Wiki: https://github.com/ben-manes/caffeine/wiki
+- Spring Caffeine 설정: https://docs.spring.io/spring-framework/reference/integration/cache/store-configuration.html#cache-store-configuration-caffeine
+
+---
+
+## 2) 동작방식
+
+### 2-1. Eviction 정책 3축 (표)
+
+| 축 | 주요 옵션 | 무엇을 줄이려는가 | 언제 유용한가 | 흔한 실수/주의점 |
+| --- | --- | --- | --- | --- |
+| Size | `maximumSize`, `maximumWeight` + `weigher` | 메모리 초과와 과도한 eviction | 키 종류가 많고 트래픽이 넓게 퍼질 때 | `maximumWeight`를 "엔트리 개수 제한"으로 오해하면 안 됨 |
+| Time | `expireAfterWrite`, `expireAfterAccess`, `expireAfter(Expiry)` | 오래된(stale) 데이터 노출 | 데이터 신선도가 SLA에 직접 영향 줄 때 | "쓰기 기준 만료"와 "접근 기준 만료"를 혼동하기 쉬움 |
+| Reference | `weakKeys`, `weakValues`, `softValues` | GC 압력 상황에서 회수되지 않는 객체 | 메모리 압력 대응이 최우선일 때 | 성능 최적화 수단으로 먼저 쓰면 예측이 어려워질 수 있음 |
+
+### 2-1-1. Eviction 3축 관계도
+
+```mermaid
+flowchart LR
+    A[Cache Entry] --> B{Size 정책}
+    A --> C{Time 정책}
+    A --> D{Reference 정책}
+    B -->|초과| E[Eviction/Miss]
+    C -->|만료| E
+    D -->|GC 회수| E
+    B -->|정상| F[Hit 후보]
+    C -->|유효| F
+    D -->|유지| F
+```
+
+이 다이어그램에서 핵심은 세 가지다.
+- Size, Time, Reference는 독립적으로 설정해도 동시에 결과에 영향을 준다.
+- TTL이 남아 있어도 size/reference 조건으로 miss가 먼저 발생할 수 있다.
+- 따라서 miss 원인 분석 시 "시간 정책만" 보면 오판하기 쉽다.
+
+### 2-2. Size 기반 상세
+- `maximumSize`: 엔트리 수 기반 상한
+- `maximumWeight + weigher`: 엔트리별 비용을 정의해 가중치 합으로 제어
+- Caffeine은 admission/eviction 정책을 통해 hit ratio를 최대화하려고 시도한다(W-TinyLFU 계열)
+- 예시 시나리오: "상품 100만 건 중 자주 조회되는 1만 건만 빠르게 유지"가 목표라면 Size 제한이 기본 전략이 된다.
+
+예시:
+```kotlin
+val byCount = Caffeine.newBuilder()
+    // 최대 10,000개 엔트리
+    .maximumSize(10_000)
+    .build<String, Product>()
+
+val byWeight = Caffeine.newBuilder()
+    // 최대 가중치 50,000
+    .maximumWeight(50_000)
+    // 엔트리별 비용(예: payload 크기) 계산
+    .weigher<String, Product> { _, value -> value.payloadBytes }
+    .build<String, Product>()
+```
+
+### 2-3. Time 기반 상세
+- `expireAfterWrite`: 마지막 쓰기 시점 기준 만료
+- `expireAfterAccess`: 마지막 접근 시점 기준 만료
+- `expireAfter(Expiry)`: 엔트리별 커스텀 만료 정책
+- 예시 시나리오: "가격은 10초마다 바뀔 수 있다"는 조건이면 `expireAfterWrite(10s)`가 명확하다.
+
+예시:
+```kotlin
+val writeBased = Caffeine.newBuilder()
+    // "생성/갱신 후 10초" 기준 만료
+    .expireAfterWrite(Duration.ofSeconds(10))
+    .build<String, Product>()
+
+val accessBased = Caffeine.newBuilder()
+    // "마지막 접근 후 10초" 동안 접근 없으면 만료
+    .expireAfterAccess(Duration.ofSeconds(10))
+    .build<String, Product>()
+```
+
+### 2-4. Reference 기반 상세
+- `weakKeys`: key를 약한 참조로 관리
+- `weakValues`, `softValues`: value를 GC 정책과 연계
+- 참조 기반 정책은 성능보다 메모리 압력 대응 목적일 때 선택하는 편이 안전하다.
+- 예시 시나리오: "개발 툴/백오피스처럼 메모리 급등 구간이 잦다"면 Reference 정책을 제한적으로 검토한다.
+
+예시:
+```kotlin
+val gcSensitive = Caffeine.newBuilder()
+    // key를 weak reference로 관리
+    .weakKeys()
+    .build<String, Product>()
+```
+
+정리:
+- Size는 "얼마나 담을지"를 정한다.
+- Time은 "얼마나 오래 둘지"를 정한다.
+- Reference는 "GC 상황에서 어떻게 회수될지"를 정한다.
+
+출처:
+- Eviction: https://github.com/ben-manes/caffeine/wiki/Eviction
+- Design: https://github.com/ben-manes/caffeine/wiki/Design
+
+---
+
+## 3) expire vs refresh (표 + 예시)
+
+### 3-1. 개념 비교
+
+| 항목 | `expireAfterWrite` | `refreshAfterWrite` |
+| --- | --- | --- |
+| 트리거 | 만료 시점 도달 | 읽기 시점에 refresh 대상 확인 |
+| 만료 후 조회 결과 | miss 발생 가능 | 기존 값 반환 가능 |
+| 갱신 실행 방식 | 새 조회 시 로딩 | 조회를 계기로 갱신 시작 |
+| 목적 | 엄격한 유효기간 | 지연 스파이크를 줄인 점진 갱신 |
+
+### 3-1-1. expire vs refresh 시간축
+
+```mermaid
+flowchart LR
+    A[값 적재] --> B[시간 경과]
+    B --> C{expireAfterWrite}
+    C -->|조회 발생| D[만료로 miss 가능]
+    B --> E{refreshAfterWrite}
+    E -->|조회 발생| F[기존 값 반환 + refresh 시작]
+```
+
+이 다이어그램에서 볼 포인트는 두 가지다.
+- `expireAfterWrite`는 만료 후 miss가 날 수 있는 정책이다.
+- `refreshAfterWrite`는 cron처럼 자동으로 도는 주기 갱신이 아니라 조회 트리거 기반이다.
+
+### 3-2. 코드 예시
+
+```kotlin
+// expire: ttl 이후에는 로딩이 완료되기 전까지 miss가 발생할 수 있음
+val expireCache = Caffeine.newBuilder()
+    .expireAfterWrite(Duration.ofSeconds(10))
+    .build<String, Product> { key -> loadFromStore(key) }
+
+// refresh: 조회 시 refresh가 트리거되고, refresh 중 기존값을 반환할 수 있음
+val refreshCache = Caffeine.newBuilder()
+    .refreshAfterWrite(Duration.ofSeconds(10))
+    .build<String, Product> { key -> loadFromStore(key) }
+```
+
+출처:
+- Refresh: https://github.com/ben-manes/caffeine/wiki/Refresh
+
+---
+
+## 4) Spring 래핑 vs Native Caffeine 직접제어
+
+### 4-1. 비교 표
+
+| 관점 | Spring 래핑 (`@Cacheable`, `CaffeineCacheManager`) | Native Caffeine + 수동 cache-aside |
+| --- | --- | --- |
+| 생산성 | 높음 (선언형) | 중간 (직접 구현) |
+| 로직 가시성 | 메서드 단위로 분산될 수 있음 | 서비스 플로우에 집중되어 명확 |
+| source/TTL 응답 노출 | 기본 추상화 범위 밖 | 직접 구현 가능 |
+| L1(Local) + L2(Redis) 세밀 제어 | 추가 설계 필요 | 자연스럽게 구현 가능 |
+| 학습 목적 적합성 | 개념 입문에 유리 | 내부 흐름 학습에 유리 |
+
+### 4-1-1. 방식 선택 가이드
+
+```mermaid
+flowchart TD
+    A[캐시 적용 요구사항 정리] --> B{응답에 source/TTL 노출 필요?}
+    B -->|예| C[Native cache-aside 우선 검토]
+    B -->|아니오| D{L1 + L2 제어가 핵심?}
+    D -->|예| C
+    D -->|아니오| E{개발 생산성/선언형 우선?}
+    E -->|예| F[Spring 래핑 우선]
+    E -->|아니오| C
+```
+
+이 다이어그램은 우열 비교가 아니라 선택 기준을 정리하기 위한 도식이다.
+- 메서드 결과 캐싱 중심이면 Spring 래핑이 빠르게 적용된다.
+- 계층 캐시 오케스트레이션과 응답 의미 제어가 핵심이면 Native 방식이 유리하다.
+
+### 4-2. 왜 이 study는 Native를 선택했는가
+현재 study 요구사항은 다음과 같다.
+- 조회 source(`LOCAL/REDIS/MISS`)를 응답으로 내려야 함
+- `ttlRemainingSeconds`를 source 기준으로 내려야 함
+- `seed` 재적재 시 local invalidate 정책 제어 필요
+- local clear API 같은 운영/학습 훅 필요
+
+이 요구사항은 "캐시 적용"보다 "캐시 흐름 자체"가 핵심이라, 수동 cache-aside가 더 직접적이다.
+
+### 4-3. Spring 래핑의 한계로 해석하면 안 되는 이유
+그렇지 않다. Spring 래핑은 메서드 결과 캐싱에 매우 효율적이다.
+다만 이번 주제는 "결과 캐싱"이 아니라 "계층 캐시 오케스트레이션"이 중심이라 선택이 달라진 케이스다.
+
+### 4-4. Caffeine vs Ehcache (공식 근거 기반 비교)
+확인 기준 날짜: 2026-03-22
+
+| 관점 | Caffeine (공식 근거) | Ehcache (공식 근거) | 실무 해석 |
+| --- | --- | --- | --- |
+| Spring 통합 경로 | Spring 문서에서 `org.springframework.cache.caffeine` 기반 `CaffeineCacheManager`를 직접 제공 | Spring 문서에서 Ehcache 3.x는 JSR-107(JCache) 준수로 별도 전용 지원 없이 JCache 경로 사용 | Spring 캐시 추상화에서 단순/직접 통합은 Caffeine이 직관적이고, 표준 API(JCache) 중심이면 Ehcache도 자연스럽다 |
+| 설계 목표 | Caffeine 공식 문서/README는 high performance, near optimal hit rate를 강조하고 Design 문서에서 W-TinyLFU 정책을 명시 | Ehcache 문서는 tiered caching(heap/off-heap/disk/clustered)과 운영 제약/설정 규칙을 상세히 제공 | 인메모리 hit ratio와 단순 고성능 최적화는 Caffeine이 강점이고, 저장 계층 전략과 운영 옵션은 Ehcache가 강점이다 |
+| 저장 계층/지속성 | 기본적으로 로컬 인메모리 캐시에 집중 | Tiering 문서에서 off-heap/disk/clustered를 다루고, XML 문서에서 `PersistentCacheManager`/`<persistence>`를 명시 | 캐시를 메모리 밖 계층까지 설계하려면 Ehcache의 기능 폭이 넓다 |
+| 쓰기 연동 기능 | cache-aside/loader 중심 설계가 일반적 | Writers 문서에서 write-through/write-behind, batching/coalescing/concurrency 옵션 제공 | 시스템 오브 레코드와 쓰기 연동 정책이 중요하면 Ehcache 설계 옵션이 유용하다 |
+
+### 4-4-1. 왜 Caffeine이 좋다고 말하는가 (조건부)
+- "Spring 기반 로컬 캐시를 빠르게 붙이고 튜닝하고 싶다"는 조건에서는 Caffeine이 더 단순한 선택이 되기 쉽다.
+- "near optimal hit rate"와 W-TinyLFU 기반 정책을 공식 문서에서 명시하므로, 성능/히트율 관점의 설명 근거가 명확하다.
+- 다만 이 평가는 "인메모리 로컬 캐시 중심" 조건에서 유효하다. 저장 계층/지속성/쓰기 연동이 핵심이면 Ehcache가 더 맞을 수 있다.
+
+### 4-4-2. 선택 가이드 (요약표)
+
+| 요구사항 | 더 잘 맞는 선택 | 이유 |
+| --- | --- | --- |
+| Spring에서 빠르게 로컬 캐시 적용 + 코드 간결성 우선 | Caffeine | Spring의 전용 Caffeine 통합 경로가 단순하고, builder 기반 튜닝이 직관적 |
+| 히트율 중심의 인메모리 캐시 최적화 | Caffeine | 공식 Design 문서에서 W-TinyLFU 기반 hit rate 최적화 방향을 명시 |
+| off-heap/disk/clustered 계층 설계가 필요 | Ehcache | 공식 Tiering 문서에서 다중 계층과 제약 조건을 체계적으로 제공 |
+| JCache(JSR-107) 표준 API 중심 운영 | Ehcache | Spring 문서에서 Ehcache 3.x의 JSR-107 준수와 JCache 경로를 명시 |
+| write-behind 등 쓰기 경로 제어가 중요 | Ehcache | 공식 Writers 문서에서 배치/코얼레싱/동시성 옵션을 제공 |
+
+출처:
+- Spring cache store config: https://docs.spring.io/spring-framework/reference/integration/cache/store-configuration.html#cache-store-configuration-caffeine
+- Spring `CaffeineCacheManager` Javadoc: https://docs.enterprise.spring.io/spring-framework/docs/6.1.22/javadoc-api/org/springframework/cache/caffeine/CaffeineCacheManager.html
+- Caffeine README: https://github.com/ben-manes/caffeine
+- Caffeine Design: https://github.com/ben-manes/caffeine/wiki/Design
+- Ehcache 3.11 JSR-107 Provider: https://www.ehcache.org/documentation/3.11/107.html
+- Ehcache 3.11 Tiering: https://www.ehcache.org/documentation/3.11/tiering.html
+- Ehcache 3.11 XML (`<persistence>`): https://www.ehcache.org/documentation/3.11/xml.html
+- Ehcache 3.11 Writers (write-behind): https://www.ehcache.org/documentation/3.11/writers.html
+
+---
+
+## 5) 응용방식
+
+### 5-1. 패턴별 적용 가이드 (표)
+
+| 패턴 | 적합한 상황 | 핵심 구현 포인트 |
+| --- | --- | --- |
+| Cache-aside | 가장 일반적인 읽기 최적화 | miss 시 하위 저장소 조회 + 상위 캐시 적재 |
+| Read-through (LoadingCache) | 로딩 규칙이 일관적일 때 | loader 예외/타임아웃 설계 |
+| Write-through/Write-behind | 쓰기 일관성과 처리량 균형 | 실패 재시도/순서 보장 정책 필요 |
+| L1 + L2 계층 캐시 | 저지연 + 인스턴스 간 데이터 공유 | TTL 관계, 무효화 전파 전략 설계 |
+
+### 5-2. 운영 관측성 추천
+- `recordStats()`로 hit/miss/eviction 지표 수집
+- removal listener로 eviction cause 추적
+- 지표 예시: hit ratio, load latency, eviction count, stale read 비율
+
+### 5-3. `recordStats()` 자세히 보기
+
+`recordStats()`를 켜면 캐시가 내부 통계를 누적한다.
+
+```kotlin
+val cache = Caffeine.newBuilder()
+    // 통계 수집 활성화
+    .recordStats()
+    .maximumSize(10_000)
+    .build<String, Product>()
+
+val stats = cache.stats()
+println("hitCount = ${stats.hitCount()}")
+println("missCount = ${stats.missCount()}")
+println("hitRate = ${stats.hitRate()}")
+println("evictionCount = ${stats.evictionCount()}")
+println("averageLoadPenalty(ns) = ${stats.averageLoadPenalty()}")
+```
+
+어떻게 해석하면 좋은가:
+- `hitRate`가 낮다: 키 설계/TTL/최대 크기 중 하나가 맞지 않을 가능성
+- `evictionCount`가 급증한다: 캐시 크기가 너무 작거나 트래픽 패턴이 변했을 가능성
+- `averageLoadPenalty`가 높다: miss 시 하위 저장소(DB/Redis/API) 지연이 큰 상태
+
+실무에서 많이 쓰는 해석 순서:
+1. `hitRate` 단독으로 보지 말고 `request 수`와 같이 본다.
+2. `evictionCount` 급증 구간의 배포/트래픽 이벤트를 같이 본다.
+3. `averageLoadPenalty`가 오르면 캐시가 아니라 하위 저장소 지연부터 확인한다.
+4. 정책 변경 전/후를 같은 시간대 기준으로 비교한다(피크 시간 고정).
+
+주의:
+- 통계는 "방향성" 파악 용도다. 한 지표만 보고 정책을 바꾸면 오판할 수 있다.
+- `hitRate`만 높이고 stale 문제가 커지면 오히려 비즈니스 품질은 떨어질 수 있다.
+
+---
+
+## 6) 유의사항 (사이드 이펙트)
+
+### 6-1. 사이드 이펙트 요약표
+
+| 이슈 | 실제로 보이는 증상 | 왜 발생하나 | 완화 전략 |
+| --- | --- | --- | --- |
+| TTL 의미 혼동 | "Redis는 30초인데 응답 TTL은 10초"처럼 보여 장애로 오해 | L1/L2 TTL 기준이 다름 | `source`와 TTL 의미를 API 계약으로 고정 |
+| stale 데이터 노출[1] | 방금 수정했는데 이전 값이 잠깐 보임 | refresh/비동기 갱신 특성 | 쓰기 시 invalidate, 중요 경로는 expire 기반 설계 |
+| stampede[2] | 특정 순간 DB/Redis QPS가 급등하고 지연이 연쇄 발생 | 동시 miss 요청 집중 | loading/async, jitter TTL, key 단위 lock |
+| reference 정책 부작용 | 캐시 hit/miss 패턴이 예측과 다름 | GC 영향 + 참조 전략 | strong 기본, 메모리 압력 구간에 한정 적용 |
+| 테스트 불안정 | 같은 테스트가 가끔만 실패 | sleep 의존 시간 레이스 | `Ticker` 기반 테스트 고려 |
+
+### 6-2. 체크리스트
+- 캐시 목적(성능/일관성/비용절감)을 명시한다.
+- TTL, invalidation, fallback 정책을 문서화한다.
+- 관측 지표 없이 감으로 정책을 조정하지 않는다.
+
+각주:
+- [1] stale 데이터: 최신 원본 데이터와 캐시 데이터가 잠시 불일치하는 상태
+- [2] stampede: 동일 키 miss가 동시에 몰리며 하위 저장소 부하가 폭증하는 현상
+
+---
+
+## 7) 더 깊은 내부 구조 보기
+
+아래 심화 문서에서 Caffeine의 내부 자료구조/버퍼/maintenance 흐름을 더 상세히 다룬다.
+- [Caffeine 내부구조 심화 문서](./2026-03-22_caffeine-local-cache-internals-deep-dive.md)
+
+---
+
+## 공식 참고자료
+- Caffeine GitHub: https://github.com/ben-manes/caffeine
+- Caffeine Wiki Home: https://github.com/ben-manes/caffeine/wiki
+- Caffeine Design: https://github.com/ben-manes/caffeine/wiki/Design
+- Caffeine Eviction: https://github.com/ben-manes/caffeine/wiki/Eviction
+- Caffeine Refresh: https://github.com/ben-manes/caffeine/wiki/Refresh
+- Spring Caffeine Store Config: https://docs.spring.io/spring-framework/reference/integration/cache/store-configuration.html#cache-store-configuration-caffeine
+- Spring `CaffeineCacheManager` Javadoc: https://docs.enterprise.spring.io/spring-framework/docs/6.1.22/javadoc-api/org/springframework/cache/caffeine/CaffeineCacheManager.html
+- Ehcache 3.11 Docs Home: https://www.ehcache.org/documentation/3.11/
+- Ehcache 3.11 JSR-107 Provider: https://www.ehcache.org/documentation/3.11/107.html
+- Ehcache 3.11 Tiering: https://www.ehcache.org/documentation/3.11/tiering.html
+- Ehcache 3.11 XML: https://www.ehcache.org/documentation/3.11/xml.html
+- Ehcache 3.11 Writers: https://www.ehcache.org/documentation/3.11/writers.html

--- a/dummy/2026-03-22_caffeine-local-cache-deep-dive.md
+++ b/dummy/2026-03-22_caffeine-local-cache-deep-dive.md
@@ -81,6 +81,33 @@ val asyncCache = Caffeine.newBuilder()
 | `LoadingCache<K, V>` | miss 로딩 규칙이 명확할 때 | 코드 간결, 자동 로딩 | loader 실패/지연 시 영향 범위를 설계해야 함 |
 | `AsyncLoadingCache<K, V>` | 로딩 지연이 크고 비동기 처리가 필요할 때 | 스레드 점유 감소, 병렬 처리 유리 | Future 체인/타임아웃/예외 처리 설계 필요 |
 
+### 1-4-1. study 코드에서의 세 가지 캐시
+
+`StudyCacheTierService`는 같은 origin 데이터를 세 가지 Caffeine 패턴으로 읽어본다. `Cache`는 수동 cache-aside, `LoadingCache`는 자동 loader, `refreshAfterWriteCache`는 stale 값을 잠깐 유지하면서 갱신하는 실습용이다.
+
+```kotlin
+private val originData = ConcurrentHashMap<String, String>()
+
+private val cacheAsideCache: Cache<String, String> = Caffeine.newBuilder()
+    .expireAfterWrite(Duration.ofSeconds(properties.localTtlSeconds))
+    .maximumSize(properties.localMaximumSize)
+    .recordStats()
+    .build()
+
+private val loadingCache: LoadingCache<String, String> = Caffeine.newBuilder()
+    .expireAfterWrite(Duration.ofSeconds(properties.localTtlSeconds))
+    .maximumSize(properties.localMaximumSize)
+    .recordStats()
+    .build { key -> loadForLoadingCache(key) }
+
+private val refreshAfterWriteCache: LoadingCache<String, String> = Caffeine.newBuilder()
+    .refreshAfterWrite(Duration.ofSeconds(properties.refreshAfterWriteSeconds))
+    .expireAfterWrite(Duration.ofSeconds(properties.localTtlSeconds))
+    .maximumSize(properties.localMaximumSize)
+    .recordStats()
+    .build { key -> loadForRefreshCache(key) }
+```
+
 ### 1-5. Spring 래핑 사용 예시
 
 ```kotlin
@@ -243,6 +270,22 @@ val refreshCache = Caffeine.newBuilder()
     .build<String, Product> { key -> loadFromStore(key) }
 ```
 
+study 코드에서는 origin 값을 바꿔도 캐시를 무효화하지 않는 테스트로 stale 값을 관찰한다. 이후 `refresh(key)`를 호출하면 loader가 다시 실행되고 새 값을 볼 수 있다.
+
+```kotlin
+studyCacheTierService.putData("product:3", "old")
+studyCacheTierService.getWithRefreshAfterWrite("product:3").value // old
+
+studyCacheTierService.putData(
+    key = "product:3",
+    value = "new",
+    invalidateCaches = false,
+)
+
+studyCacheTierService.getWithRefreshAfterWrite("product:3").value // old
+studyCacheTierService.refreshNow("product:3").value // new
+```
+
 출처:
 - Refresh: https://github.com/ben-manes/caffeine/wiki/Refresh
 
@@ -279,10 +322,43 @@ flowchart TD
 
 ### 4-2. 왜 이 study는 Native를 선택했는가
 현재 study 요구사항은 다음과 같다.
-- 조회 source(`LOCAL/REDIS/MISS`)를 응답으로 내려야 함
-- `ttlRemainingSeconds`를 source 기준으로 내려야 함
-- `seed` 재적재 시 local invalidate 정책 제어 필요
-- local clear API 같은 운영/학습 훅 필요
+- 조회 source(`LOCAL_CACHE/LOADER/MISS`)를 응답으로 내려야 함
+- cache-aside, loading, refresh 패턴의 차이를 같은 데이터로 비교해야 함
+- origin 데이터 변경 시 캐시 invalidate 여부를 실험해야 함
+- hit/miss/eviction과 loader 호출 수를 함께 관찰해야 함
+
+Native Caffeine을 직접 쓰면 응답에 hit/miss 원인을 담거나, 특정 캐시만 골라 비우는 코드가 명시적으로 드러난다.
+
+```kotlin
+fun getWithCacheAside(key: String): CacheLookupResponse {
+    cacheAsideCache.getIfPresent(key)?.let { cached ->
+        return CacheLookupResponse(
+            key = key,
+            value = cached,
+            pattern = CachePattern.CACHE_ASIDE,
+            source = CacheSource.LOCAL_CACHE,
+            message = "Cache-aside hit",
+        )
+    }
+
+    val loaded = originData[key] ?: return CacheLookupResponse(
+        key = key,
+        value = null,
+        pattern = CachePattern.CACHE_ASIDE,
+        source = CacheSource.MISS,
+        message = "Origin data does not exist",
+    )
+
+    cacheAsideCache.put(key, loaded)
+    return CacheLookupResponse(
+        key = key,
+        value = loaded,
+        pattern = CachePattern.CACHE_ASIDE,
+        source = CacheSource.LOADER,
+        message = "Loaded origin data and populated Caffeine",
+    )
+}
+```
 
 이 요구사항은 "캐시 적용"보다 "캐시 흐름 자체"가 핵심이라, 수동 cache-aside가 더 직접적이다.
 
@@ -376,6 +452,25 @@ println("averageLoadPenalty(ns) = ${stats.averageLoadPenalty()}")
 주의:
 - 통계는 "방향성" 파악 용도다. 한 지표만 보고 정책을 바꾸면 오판할 수 있다.
 - `hitRate`만 높이고 stale 문제가 커지면 오히려 비즈니스 품질은 떨어질 수 있다.
+
+study 코드의 stats 응답은 Caffeine 통계와 loader 호출 수를 같이 보여준다. Caffeine의 hit/miss와 실제 하위 저장소 로딩 횟수를 함께 봐야 캐시 정책을 해석하기 쉽다.
+
+```kotlin
+fun getStats(cacheName: String): CacheStatsResponse {
+    val cache = cacheByName(cacheName)
+    val stats = cache.stats()
+    return CacheStatsResponse(
+        cacheName = cacheName,
+        requestCount = stats.requestCount(),
+        hitCount = stats.hitCount(),
+        missCount = stats.missCount(),
+        hitRate = stats.hitRate(),
+        evictionCount = stats.evictionCount(),
+        estimatedSize = cache.estimatedSize(),
+        loaderCallCount = loaderCount(cacheName),
+    )
+}
+```
 
 ---
 

--- a/dummy/2026-03-22_caffeine-local-cache-internals-deep-dive.md
+++ b/dummy/2026-03-22_caffeine-local-cache-internals-deep-dive.md
@@ -102,6 +102,21 @@ fun getData(key: String): Response {
 }
 ```
 
+study 코드에서는 이 흐름을 응답의 `source`로 드러낸다. `LOCAL_CACHE`면 Caffeine hit, `LOADER`면 origin 조회 후 적재, `MISS`면 origin에도 값이 없는 상태다. 아래 코드는 원본 메서드의 핵심 흐름만 줄인 형태다.
+
+```kotlin
+fun getWithCacheAside(key: String): CacheLookupResponse {
+    cacheAsideCache.getIfPresent(key)?.let { cached ->
+        return hitFromLocalCache(key, cached)
+    }
+
+    val loaded = originData[key] ?: return miss(key)
+
+    cacheAsideCache.put(key, loaded)
+    return loadedFromOrigin(key, loaded)
+}
+```
+
 겉으로는 단순하지만, 내부에서는 아래와 같은 일이 이어진다.
 
 ### 3-1. 단계별 동작 표
@@ -222,6 +237,21 @@ flowchart LR
 2. lower tier 지연과 local cache miss를 분리해서 본다.
 3. TTL 문제인지, size 문제인지, refresh 오해인지 분리한다.
 4. 정책을 바꾸기 전에 키 분포와 트래픽 패턴을 함께 본다.
+
+실습 코드에서는 아래처럼 `stats()`와 loader count를 같이 읽는다. `missCount`가 늘어도 loader 호출이 항상 같은 의미는 아니므로, Caffeine 통계와 애플리케이션 카운터를 나눠 보는 습관이 필요하다.
+
+```kotlin
+val stats = cache.stats()
+
+CacheStatsResponse(
+    requestCount = stats.requestCount(),
+    hitCount = stats.hitCount(),
+    missCount = stats.missCount(),
+    evictionCount = stats.evictionCount(),
+    estimatedSize = cache.estimatedSize(),
+    loaderCallCount = loaderCount(cacheName),
+)
+```
 
 ---
 

--- a/dummy/2026-03-22_caffeine-local-cache-internals-deep-dive.md
+++ b/dummy/2026-03-22_caffeine-local-cache-internals-deep-dive.md
@@ -1,0 +1,233 @@
+# Caffeine 내부구조 심화: Low-level 동작 관점
+
+이 문서는 [Caffeine Local Cache 딥다이브](./2026-03-22_caffeine-local-cache-deep-dive.md)의 심화편이다.
+목표는 API 이름을 외우는 것이 아니라, Caffeine이 왜 빠르고 왜 예상과 다른 시점에 miss/eviction/refresh가 보일 수 있는지를 내부 동작 관점에서 이해하는 것이다.
+
+---
+
+## 1) 큰 그림: Caffeine이 실제로 하는 일
+
+Caffeine은 "값을 담아두는 Map"이라기보다, "어떤 값을 남기고 어떤 값을 밀어낼지 계속 판단하는 정책 엔진"에 가깝다.
+
+### 1-1. 핵심 개념 표
+
+| 개념 | 내부에서 하는 일 | 왜 필요한가 | 사용자가 체감하는 효과 | 이해 포인트 |
+| --- | --- | --- | --- | --- |
+| Admission | 새로 들어온 엔트리를 바로 보호하지 않고 평가한다 | 일회성 트래픽이 캐시를 오염시키지 않게 하기 위해 | burst 트래픽에서도 hit ratio가 덜 무너진다 | "들어왔다"와 "오래 남는다"는 다른 문제다 |
+| Eviction | 남길 가치가 낮은 엔트리를 밀어낸다 | 메모리 한도와 hit ratio를 동시에 관리하기 위해 | 오래된 값이나 덜 중요한 값이 사라진다 | TTL이 남아 있어도 size 정책으로 먼저 빠질 수 있다 |
+| Read/Write Buffer | 접근 이벤트를 즉시 전역 구조에 반영하지 않고 모은다 | hot path에서 락 경쟁을 줄이기 위해 | 읽기 성능이 좋아진다 | 정책 반영이 항상 즉시 보이지는 않는다 |
+| Maintenance | 모아둔 이벤트를 정리하며 eviction/expiration을 수행한다 | 성능과 정책 정확도의 균형을 맞추기 위해 | "왜 지금 정리됐지?" 같은 현상이 생길 수 있다 | 만료나 정리가 요청 순간과 정확히 일치하지 않을 수 있다 |
+| Frequency Sketch | 최근 빈도를 압축 형태로 추적한다 | 자주 쓰이는 키를 더 오래 살리기 위해 | 반복 조회 키의 생존율이 높아진다 | 단순 LRU보다 hit ratio에 유리하다 |
+
+### 1-2. 전체 흐름 다이어그램
+
+```mermaid
+flowchart LR
+    A[read / write 요청] --> B[read/write buffer 기록]
+    B --> C[maintenance]
+    C --> D[admission 판단]
+    D --> E[window / probation / protected 조정]
+    C --> F[expiration 검사]
+    C --> G[eviction 수행]
+```
+
+이 그림에서 봐야 하는 포인트는 세 가지다.
+- 요청이 들어올 때마다 모든 정책이 즉시 확정되는 구조가 아니다.
+- 접근 기록은 버퍼에 쌓였다가 maintenance에서 반영된다.
+- eviction, expiration, admission은 따로 노는 기능이 아니라 maintenance 안에서 함께 관찰되는 정책들이다.
+
+출처:
+- Caffeine Design: https://github.com/ben-manes/caffeine/wiki/Design
+
+---
+
+## 2) 내부 구역 모델: 왜 단일 LRU가 아닌가
+
+단일 LRU는 "최근에 한 번 들어온 값"과 "계속 자주 쓰이는 값"을 충분히 구분하지 못한다.
+Caffeine은 이 문제를 줄이기 위해 신규 유입 구역과 보호 구역을 나눠서 관리하는 사고방식을 사용한다.
+
+### 2-1. 구역별 역할 표
+
+| 구역 | 쉽게 풀면 | 어떤 데이터가 머무는가 | 언제 이동하는가 | 왜 필요한가 |
+| --- | --- | --- | --- | --- |
+| Window | 신규 진입 구역 | 막 들어온 엔트리 | 재접근되거나 경쟁에서 살아남으면 다음 구역으로 이동 | 새 트래픽을 바로 버리지 않고 한번 받아본다 |
+| Probation | 시험 구역 | 일단 살아남았지만 아직 강하게 보호되지는 않는 엔트리 | 다시 접근되면 protected로 승격, 밀리면 제거 | 일회성 접근과 반복 접근을 구분한다 |
+| Protected | 보호 구역 | 반복적으로 가치가 증명된 엔트리 | 보호 한도를 넘기면 일부가 probation으로 내려감 | 자주 쓰는 키를 쉽게 잃지 않게 한다 |
+
+### 2-2. 구역 이동 다이어그램
+
+```mermaid
+flowchart LR
+    A[새 엔트리 유입] --> B[Window]
+    B --> C[Probation]
+    C -->|재접근| D[Protected]
+    D -->|보호 한도 초과| C
+    C -->|경쟁에서 밀림| E[Evicted]
+    B -->|가치 낮음| E
+```
+
+이 구조를 실무 언어로 바꾸면 다음과 같다.
+- Window는 "신규 손님 대기석"이다.
+- Probation은 "한번 더 올지 보는 구간"이다.
+- Protected는 "계속 오는 핵심 손님 자리"다.
+
+### 2-3. 조회 패턴 예시 표
+
+| 상황 | 단순 LRU에서 생길 수 있는 문제 | Caffeine 구역 모델이 유리한 이유 |
+| --- | --- | --- |
+| 이벤트로 인해 새로운 키 10만 개가 짧게 유입 | 기존 hot key가 대량으로 밀릴 수 있다 | 신규 키를 바로 핵심 구역으로 넣지 않아 hot key 보호에 유리하다 |
+| 어떤 상품 키가 반복적으로 계속 조회 | 신규 유입 키와 섞이며 생존이 불안정할 수 있다 | 반복 조회가 확인되면 protected에 가까워져 오래 남기 쉽다 |
+| 일회성 조회가 매우 많음 | 캐시 공간이 일회성 요청으로 쉽게 오염된다 | probation 경쟁을 통해 반복 사용 키를 상대적으로 살리기 쉽다 |
+
+출처:
+- Caffeine Design: https://github.com/ben-manes/caffeine/wiki/Design
+
+---
+
+## 3) 읽기, 쓰기, 정리는 어떻게 이어지는가
+
+아래는 cache-aside 서비스에서 자주 보는 흐름이다.
+
+```kotlin
+fun getData(key: String): Response {
+    // 1) local cache read
+    cache.getIfPresent(key)?.let { return hit(it) }
+
+    // 2) lower tier read (redis/db)
+    val loaded = loadFromRedis(key) ?: return miss()
+
+    // 3) local cache write
+    cache.put(key, loaded)
+    return loadedFromRedis(loaded)
+}
+```
+
+겉으로는 단순하지만, 내부에서는 아래와 같은 일이 이어진다.
+
+### 3-1. 단계별 동작 표
+
+| 시점 | 내부 동작 | 사용자 관점에서 보이는 결과 | 주의할 점 |
+| --- | --- | --- | --- |
+| `getIfPresent(key)` hit | 값 반환 + 접근 이벤트 기록 | 빠른 응답 | 접근 기록이 바로 전역 정책에 반영되는 것은 아니다 |
+| `getIfPresent(key)` miss | 값 부재 확인 | 하위 저장소 조회 발생 | 실제 miss 원인이 TTL 만료인지 size eviction인지 바로 구분되지는 않는다 |
+| `cache.put(key, value)` | 새 엔트리 삽입 + 정책 적용 후보 등록 | 다음 조회부터 local hit 가능 | 넣었다고 해서 곧바로 장기 생존이 확정되지는 않는다 |
+| maintenance 수행 | 버퍼 소모 + eviction/expiration 정리 | 어떤 시점에 갑자기 miss가 보일 수 있음 | 사용자는 "방금까지 있던 값이 왜 사라졌지?"처럼 느낄 수 있다 |
+
+### 3-2. 읽기/쓰기/정리 관계 다이어그램
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant Cache as Caffeine Cache
+    participant Buffer as Read/Write Buffer
+    participant Maint as Maintenance
+    participant Store as Redis/DB
+
+    App->>Cache: getIfPresent(key)
+    Cache-->>App: hit or miss
+    Cache->>Buffer: access event 기록
+    App->>Store: miss 시 lower tier 조회
+    Store-->>App: value or null
+    App->>Cache: put(key, value)
+    Cache->>Buffer: write event 기록
+    Buffer->>Maint: 이벤트 전달
+    Maint->>Cache: eviction / expiration / reorder 반영
+```
+
+이 다이어그램에서 중요한 점은 "조회 결과를 돌려주는 시점"과 "정책 정리가 반영되는 시점"이 항상 완전히 같지 않을 수 있다는 점이다.
+
+---
+
+## 4) expire, refresh, maintenance는 서로 무엇이 다른가
+
+이 세 개가 섞여 보이면 Caffeine이 어렵게 느껴진다.
+핵심은 "만료", "갱신", "정리 시점"이 서로 다른 문제라는 점이다.
+
+### 4-1. 비교 표
+
+| 항목 | `expireAfterWrite` | `refreshAfterWrite` | maintenance |
+| --- | --- | --- | --- |
+| 의미 | 일정 시간이 지나면 엔트리를 만료 대상으로 본다 | 일정 시간이 지나면 갱신 대상이 될 수 있다 | 버퍼 이벤트를 반영하며 정책을 실제로 정리한다 |
+| 조회 시 체감 | 만료 후에는 miss가 날 수 있다 | refresh 중에는 기존 값이 반환될 수 있다 | "왜 지금 정리됐지?" 같은 타이밍 차이를 만든다 |
+| 언제 실행되나 | 시간 조건 충족 후 접근/정리 시 반영 | 공식 문서 기준, 엔트리가 조회될 때 refresh가 실제로 시작된다 | 접근/쓰기 이후 내부 정리 시점에 수행된다 |
+| 적합한 상황 | 신선도 보장이 우선일 때 | 응답 지연 완화가 우선일 때 | 직접 고르는 옵션이라기보다 내부 작동 메커니즘 |
+| 흔한 오해 | TTL이 지나면 그 순간 즉시 사라진다고 생각 | cron처럼 주기적으로 자동 갱신된다고 생각 | 정리가 항상 동기적으로 즉시 보인다고 생각 |
+
+### 4-2. 시간축 다이어그램
+
+```mermaid
+flowchart LR
+    A[값 적재] --> B[시간 경과]
+    B --> C{expireAfterWrite}
+    C -->|조회 발생| D[miss 가능]
+    B --> E{refreshAfterWrite}
+    E -->|조회 발생| F[기존 값 반환 + 비동기 refresh 가능]
+    B --> G[maintenance 시점]
+    G --> H[정책 반영 및 정리]
+```
+
+### 4-3. 실제로 많이 나오는 질문 표
+
+| 관찰한 현상 | 내부에서 볼 수 있는 이유 | 먼저 확인할 것 |
+| --- | --- | --- |
+| TTL이 지났는데 값이 바로 안 사라진다 | maintenance와 접근 시점에 따라 정리가 뒤늦게 보일 수 있다 | 접근 패턴, expiration 정책, 테스트 방식 |
+| TTL이 아직 남았다고 생각했는데 miss가 난다 | size eviction 또는 reference 정책으로 먼저 빠졌을 수 있다 | maximumSize/maximumWeight, GC 영향, hit/miss 지표 |
+| refresh를 걸었는데 자동 갱신처럼 안 보인다 | 공식 문서 기준 refresh는 조회 시점에 실제 시작된다 | 해당 키가 refresh 가능 시점 이후 실제로 조회됐는지 |
+
+출처:
+- Caffeine Refresh: https://github.com/ben-manes/caffeine/wiki/Refresh
+- Caffeine Eviction: https://github.com/ben-manes/caffeine/wiki/Eviction
+
+---
+
+## 5) 어떤 가이드라인을 기준으로 설명했는가
+
+이 문서는 임의의 비유만으로 쓴 문서가 아니다.
+아래 공식 자료의 설명 범위를 기준으로, 초심자가 이해하기 쉬운 운영 관점의 언어로 번역했다.
+
+### 5-1. 기준 자료 표
+
+| 기준 자료 | 이 문서에서 참고한 포인트 | 문서에 반영한 방식 |
+| --- | --- | --- |
+| Caffeine Design | admission, eviction, buffering, maintenance의 설계 의도 | "정책 엔진"이라는 큰 그림과 구역 모델 설명 |
+| Caffeine Eviction | size/time/reference eviction의 동작 특성 | TTL이 남아 있어도 miss가 날 수 있는 이유, eviction 3축 해석 |
+| Caffeine Refresh | refresh가 조회 시점에 실제 시작된다는 점, old value 유지 가능성 | expire vs refresh 오해 방지 표와 시간축 설명 |
+
+### 5-2. 문서 작성 원칙
+
+| 원칙 | 이유 |
+| --- | --- |
+| 내부 호출 순서를 전부 외우게 하지 않는다 | 학습 초반에는 세부 구현보다 동작 원리를 이해하는 편이 더 중요하다 |
+| 비교 가능한 내용은 표로 정리한다 | low-level 설명은 문장만 나열하면 관계가 잘 안 보이기 쉽다 |
+| 추상 용어 뒤에는 예시나 증상을 붙인다 | "왜 이 개념이 필요한가"가 보여야 기억에 남는다 |
+| 다이어그램은 흐름이 어려운 곳에만 넣는다 | 시각화가 텍스트를 보조해야지, 또 다른 해석 대상이 되면 안 된다 |
+
+---
+
+## 6) 실무에서 보이는 증상과 해석
+
+### 6-1. 증상 중심 해석 표
+
+| 증상 | 내부 원인 후보 | 확인할 지표/설정 | 실무 대응 |
+| --- | --- | --- | --- |
+| hit rate가 갑자기 하락 | burst 트래픽, size 한도 부족, 신규 키 유입 급증 | `recordStats()`, key 분포, `maximumSize` | 키 패턴 분석 후 size 조정 또는 TTL 재설계 |
+| Redis/DB 호출이 갑자기 늘어남 | local miss 증가, stampede, 예상보다 빠른 eviction | miss count, load latency, lower tier QPS | TTL 분산, loader 전략, 키 단위 보호 검토 |
+| TTL이 남아 있는 것 같은데 miss | size eviction 또는 reference 기반 회수 | eviction count, GC 로그, reference 사용 여부 | strong 기본값 재검토, size 정책 확인 |
+| refresh를 썼는데 최신 값 반영이 늦다 | refresh 대상이 되었어도 조회가 적음 | 해당 키의 실제 read 빈도 | 신선도가 더 중요하면 expire 기반으로 전환 검토 |
+| 테스트가 간헐적으로 깨진다 | 시간 기반 정책과 maintenance 타이밍이 고정되지 않음 | 테스트 코드의 sleep 사용 여부 | `Ticker` 기반 테스트 또는 여유 있는 검증 조건 사용 |
+
+### 6-2. 실전 읽기 순서
+
+1. `recordStats()`로 hit/miss/eviction을 먼저 본다.
+2. lower tier 지연과 local cache miss를 분리해서 본다.
+3. TTL 문제인지, size 문제인지, refresh 오해인지 분리한다.
+4. 정책을 바꾸기 전에 키 분포와 트래픽 패턴을 함께 본다.
+
+---
+
+## 7) 핵심 요약
+
+- Caffeine은 빠른 Map이 아니라, admission과 eviction을 분리해 hit ratio를 높이려는 정책 엔진이다.
+- `window / probation / protected`는 "신규 유입", "시험", "보호"라는 관점으로 보면 이해가 쉬워진다.
+- `expire`, `refresh`, `maintenance`는 같은 문제가 아니며, miss 시점과 정리 시점이 다르게 보일 수 있다.
+- 이 문서는 Caffeine 공식 `Design`, `Eviction`, `Refresh`를 기준으로, 운영자가 이해해야 할 수준의 안정적인 개념을 우선 설명했다.

--- a/dummy/2026-03-24_request-context-holder-practice.md
+++ b/dummy/2026-03-24_request-context-holder-practice.md
@@ -1,0 +1,82 @@
+# RequestContextHolder 실전 가이드
+
+`RequestContextHolder`는 현재 요청을 thread-bound 상태로 접근하기 위한 Spring 유틸리티다.
+핵심은 "요청 스레드 안에서는 편리하지만, 비동기/코루틴 전환 시 그대로 믿으면 깨진다"이다.
+
+## 요약
+- Spring MVC에서는 `DispatcherServlet`이 현재 요청 컨텍스트를 기본 노출하므로, 요청 스레드 안에서는 `RequestContextHolder`로 요청 메타를 쉽게 읽을 수 있다.
+- `RequestContextHolder`는 `ThreadLocal` 기반이므로 worker thread, coroutine context 전환 구간에서는 값이 비어있을 수 있다.
+- 실무 Best Practice는 **입구(Controller)에서 필요한 값을 추출해 불변 DTO로 전달**하는 방식이다.
+- 부득이하게 ThreadLocal을 코루틴에서 다뤄야 할 때는 `asContextElement`를 사용해 전파를 명시한다.
+
+## 사용법
+### 1) 학습 API 실행
+```bash
+./gradlew bootRun
+```
+### 2) 현재 요청 스레드 확인
+```bash
+http GET :8080/study/request-context/current X-Request-Id:trace-current
+```
+
+### 3) 비동기 스레드 확인
+```bash
+http GET :8080/study/request-context/async X-Request-Id:trace-async
+```
+
+### 4) 코루틴 컨텍스트 전환 확인
+```bash
+http GET :8080/study/request-context/coroutine X-Request-Id:trace-coroutine
+```
+
+## 동작 방식
+### 1) 요청 스레드 구간
+- `RequestContextHolder.currentRequestAttributes()`는 현재 스레드에 바인딩된 `RequestAttributes`를 반환한다.
+- 값이 없으면 `IllegalStateException`이 발생한다.
+
+### 2) 비동기/별도 스레드 구간
+- `CompletableFuture`나 executor worker thread로 넘어가면 같은 요청이어도 `RequestContextHolder`가 비어있을 수 있다.
+- 따라서 worker에서 `RequestContextHolder`를 직접 읽는 대신, 요청 스레드에서 추출한 `RequestMeta`를 명시적으로 전달해야 한다.
+
+### 3) 코루틴 구간
+- 코루틴이 다른 스레드로 재개(resume)되면 `ThreadLocal` 값은 자동 보장되지 않는다.
+- `RequestContextHolder`를 코루틴 내부에서 직접 의존하는 대신, 필요한 값을 인자로 전달하는 방식이 안정적이다.
+- ThreadLocal 전파가 꼭 필요하면 `asContextElement`를 사용해 어떤 값을 전파할지 명시한다.
+
+## 응용 방식
+### 1) 감사/추적 로깅
+- `X-Request-Id`, `User-Agent`, `clientIp`를 요청 입구에서 추출해 서비스/비동기 작업 로그에 함께 전달한다.
+
+### 2) 멀티테넌시/권한 문맥
+- tenant id, actor id를 요청 경계에서 추출 후 DTO로 넘겨 도메인 로직에서 일관되게 사용한다.
+
+### 3) 외부 연동 호출
+- downstream 호출 시 trace id를 전달해 end-to-end 추적성을 확보한다.
+
+## 유의사항
+### 1) `inheritable=true` 남용 금지
+- `RequestContextFilter#setThreadContextInheritable(true)`는 thread pool과 결합되면 다른 요청으로 컨텍스트가 새는 위험이 있다.
+
+### 2) 깊은 계층에서의 직접 호출 지양
+- 서비스/도메인 계층에서 `RequestContextHolder`를 직접 호출하면 테스트가 어려워지고 실행 모델 변경(비동기/배치)에 취약해진다.
+
+### 3) API 선택 기준
+- `currentRequestAttributes()`: 컨텍스트가 반드시 있어야 하는 경계에서 사용 (없으면 즉시 실패)
+- `getRequestAttributes()`: optional한 조회가 필요한 구간에서 null-safe 처리
+
+### 4) 테스트 전략
+- 단위/통합 테스트에서 `RequestContextHolder.resetRequestAttributes()`로 격리 보장
+- 요청 컨텍스트 없는 케이스(예외 발생)와 비동기 누락 케이스를 함께 검증
+
+## 참고 코드
+- 컨트롤러: `GET /study/request-context/{current|async|coroutine}`
+- 서비스:
+  - 현재 요청 조회
+  - async worker에서의 누락 확인
+  - coroutine 전환 시 누락 확인 + 명시 전달/`asContextElement` 비교
+
+## 공식 문서
+- RequestContextHolder Javadoc: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/context/request/RequestContextHolder.html
+- RequestContextFilter Javadoc: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/RequestContextFilter.html
+- RequestContextListener Javadoc: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/context/request/RequestContextListener.html
+- Kotlin Coroutines `asContextElement`: https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/as-context-element.html

--- a/dummy/2026-03-24_request-context-holder-practice.md
+++ b/dummy/2026-03-24_request-context-holder-practice.md
@@ -1,81 +1,210 @@
 # RequestContextHolder 실전 가이드
 
-`RequestContextHolder`는 현재 요청을 thread-bound 상태로 접근하기 위한 Spring 유틸리티다.
-핵심은 "요청 스레드 안에서는 편리하지만, 비동기/코루틴 전환 시 그대로 믿으면 깨진다"이다.
+`RequestContextHolder`는 현재 요청을 thread-bound 상태로 접근하기 위한 Spring 유틸리티다. 핵심은 "요청 스레드 안에서는 편리하지만, 비동기/코루틴 전환 시 그대로 믿으면 깨진다"이다.
 
 ## 요약
+
 - Spring MVC에서는 `DispatcherServlet`이 현재 요청 컨텍스트를 기본 노출하므로, 요청 스레드 안에서는 `RequestContextHolder`로 요청 메타를 쉽게 읽을 수 있다.
 - `RequestContextHolder`는 `ThreadLocal` 기반이므로 worker thread, coroutine context 전환 구간에서는 값이 비어있을 수 있다.
 - 실무 Best Practice는 **입구(Controller)에서 필요한 값을 추출해 불변 DTO로 전달**하는 방식이다.
 - 부득이하게 ThreadLocal을 코루틴에서 다뤄야 할 때는 `asContextElement`를 사용해 전파를 명시한다.
 
-## 사용법
-### 1) 학습 API 실행
-```bash
-./gradlew bootRun
-```
-### 2) 현재 요청 스레드 확인
-```bash
-http GET :8080/study/request-context/current X-Request-Id:trace-current
+## 실습 코드 구조
+
+Controller는 현재 요청, 별도 스레드, 코루틴 전환을 각각 확인할 수 있는 얇은 진입점이다. 학습 레포에서는 HTTP 호출 방법보다 아래 위임 관계를 보는 편이 더 중요하다.
+
+```kotlin
+@RestController
+@RequestMapping("/study/request-context")
+class StudyRequestContextController(
+    private val studyRequestContextService: StudyRequestContextService,
+) {
+    @GetMapping("/current")
+    fun current() = studyRequestContextService.inspectCurrentRequestContext()
+
+    @GetMapping("/async")
+    fun async() = studyRequestContextService.inspectAsyncContext()
+
+    @GetMapping("/coroutine")
+    suspend fun coroutine() = studyRequestContextService.inspectCoroutineContext()
+}
 ```
 
-### 3) 비동기 스레드 확인
-```bash
-http GET :8080/study/request-context/async X-Request-Id:trace-async
-```
+요청 메타는 `RequestContextHolder`에서 읽어 `RequestContextSnapshot`으로 고정한다. 이 스냅샷을 명시적으로 넘기면 실행 모델이 바뀌어도 필요한 값이 유지된다.
 
-### 4) 코루틴 컨텍스트 전환 확인
-```bash
-http GET :8080/study/request-context/coroutine X-Request-Id:trace-coroutine
+```kotlin
+private fun requireCurrentSnapshot(): RequestContextSnapshot {
+    val attributes = RequestContextHolder.currentRequestAttributes()
+        as? ServletRequestAttributes
+        ?: error("현재 요청 컨텍스트를 읽을 수 없습니다.")
+
+    return toSnapshot(attributes)
+}
+
+private fun toSnapshot(attributes: ServletRequestAttributes): RequestContextSnapshot {
+    val request = attributes.request
+    return RequestContextSnapshot(
+        traceId = request.getHeader("X-Request-Id"),
+        method = request.method,
+        requestUri = request.requestURI,
+        clientIp = request.remoteAddr,
+        userAgent = request.getHeader("User-Agent"),
+        threadName = Thread.currentThread().name,
+    )
+}
 ```
 
 ## 동작 방식
+
+```mermaid
+sequenceDiagram
+  participant MVC as Request Thread
+  participant Holder as RequestContextHolder
+  participant Worker as Worker Thread
+  participant Coroutine as Coroutine Dispatcher
+
+  MVC->>Holder: currentRequestAttributes()
+  Holder-->>MVC: ServletRequestAttributes
+  MVC->>MVC: RequestContextSnapshot 생성
+  MVC->>Worker: snapshot 명시 전달
+  Worker->>Holder: getRequestAttributes()
+  Holder-->>Worker: null 가능
+  Worker-->>MVC: 명시 전달한 traceId 사용
+  MVC->>Coroutine: snapshot 명시 전달
+  Coroutine->>Holder: getRequestAttributes()
+  Holder-->>Coroutine: null 가능
+  Coroutine-->>MVC: 명시 전달한 traceId 사용
+```
+
 ### 1) 요청 스레드 구간
-- `RequestContextHolder.currentRequestAttributes()`는 현재 스레드에 바인딩된 `RequestAttributes`를 반환한다.
-- 값이 없으면 `IllegalStateException`이 발생한다.
+
+`currentRequestAttributes()`는 현재 스레드에 바인딩된 `RequestAttributes`를 반환한다. 값이 없으면 `IllegalStateException`이 발생하므로, 요청 컨텍스트가 반드시 있어야 하는 경계에서만 사용한다.
+
+```kotlin
+fun inspectCurrentRequestContext(): CurrentRequestContextResponse {
+    val snapshot = requireCurrentSnapshot()
+    return CurrentRequestContextResponse(
+        requestThreadName = snapshot.threadName,
+        traceId = snapshot.traceId,
+        method = snapshot.method,
+        requestUri = snapshot.requestUri,
+        clientIp = snapshot.clientIp,
+        userAgent = snapshot.userAgent,
+    )
+}
+```
 
 ### 2) 비동기/별도 스레드 구간
-- `CompletableFuture`나 executor worker thread로 넘어가면 같은 요청이어도 `RequestContextHolder`가 비어있을 수 있다.
-- 따라서 worker에서 `RequestContextHolder`를 직접 읽는 대신, 요청 스레드에서 추출한 `RequestMeta`를 명시적으로 전달해야 한다.
+
+`CompletableFuture`나 executor worker thread로 넘어가면 같은 요청이어도 `RequestContextHolder`가 비어있을 수 있다. 그래서 worker에서 holder를 다시 읽는 값과 명시 전달한 값을 비교한다.
+
+```kotlin
+fun inspectAsyncContext(): AsyncRequestContextResponse {
+    val requestSnapshot = requireCurrentSnapshot()
+
+    val workerProbe = CompletableFuture.supplyAsync({
+        val workerSnapshot = currentSnapshotOrNull()
+        AsyncWorkerProbe(
+            workerThreadName = Thread.currentThread().name,
+            traceIdFromRequestContextHolder = workerSnapshot?.traceId,
+            traceIdFromExplicitArgument = requestSnapshot.traceId,
+        )
+    }, asyncExecutor).get()
+
+    return AsyncRequestContextResponse(
+        requestThreadName = requestSnapshot.threadName,
+        requestTraceId = requestSnapshot.traceId,
+        workerThreadName = workerProbe.workerThreadName,
+        traceIdFromRequestContextHolderInWorker = workerProbe.traceIdFromRequestContextHolder,
+        traceIdFromExplicitArgumentInWorker = workerProbe.traceIdFromExplicitArgument,
+    )
+}
+```
 
 ### 3) 코루틴 구간
-- 코루틴이 다른 스레드로 재개(resume)되면 `ThreadLocal` 값은 자동 보장되지 않는다.
-- `RequestContextHolder`를 코루틴 내부에서 직접 의존하는 대신, 필요한 값을 인자로 전달하는 방식이 안정적이다.
-- ThreadLocal 전파가 꼭 필요하면 `asContextElement`를 사용해 어떤 값을 전파할지 명시한다.
+
+코루틴이 다른 스레드로 재개되면 `ThreadLocal` 값은 자동 보장되지 않는다. 아래 코드는 `RequestContextHolder` 직접 조회, 명시 전달, `asContextElement` 전파를 나란히 비교한다.
+
+```kotlin
+suspend fun inspectCoroutineContext(): CoroutineRequestContextResponse {
+    val requestSnapshot = requireCurrentSnapshot()
+
+    val switchedWithoutPropagation = withContext(coroutineDispatcher) {
+        CoroutineThreadProbe(
+            switchedThreadName = Thread.currentThread().name,
+            traceIdFromRequestContextHolder = currentSnapshotOrNull()?.traceId,
+        )
+    }
+
+    val traceIdFromExplicitArgument = withContext(coroutineDispatcher) {
+        requestSnapshot.traceId
+    }
+
+    val traceIdThreadLocal = ThreadLocal<String?>()
+    val traceIdFromContextElement = withContext(
+        coroutineDispatcher + traceIdThreadLocal.asContextElement(requestSnapshot.traceId),
+    ) {
+        traceIdThreadLocal.get()
+    }
+
+    return CoroutineRequestContextResponse(
+        requestThreadName = requestSnapshot.threadName,
+        requestTraceId = requestSnapshot.traceId,
+        switchedThreadName = switchedWithoutPropagation.switchedThreadName,
+        traceIdFromRequestContextHolderInSwitchedCoroutine = switchedWithoutPropagation.traceIdFromRequestContextHolder,
+        traceIdFromExplicitArgumentInSwitchedCoroutine = traceIdFromExplicitArgument,
+        traceIdFromThreadLocalContextElement = traceIdFromContextElement,
+    )
+}
+```
+
+테스트는 비동기/코루틴 전환에서 holder 값은 null이고, 명시 전달 값은 유지된다는 점을 검증한다.
+
+```kotlin
+bindRequest(traceId = "trace-async")
+
+val response = studyRequestContextService.inspectAsyncContext()
+
+response.traceIdFromRequestContextHolderInWorker.shouldBeNull()
+response.traceIdFromExplicitArgumentInWorker shouldBe "trace-async"
+```
 
 ## 응용 방식
+
 ### 1) 감사/추적 로깅
+
 - `X-Request-Id`, `User-Agent`, `clientIp`를 요청 입구에서 추출해 서비스/비동기 작업 로그에 함께 전달한다.
 
 ### 2) 멀티테넌시/권한 문맥
+
 - tenant id, actor id를 요청 경계에서 추출 후 DTO로 넘겨 도메인 로직에서 일관되게 사용한다.
 
 ### 3) 외부 연동 호출
+
 - downstream 호출 시 trace id를 전달해 end-to-end 추적성을 확보한다.
 
 ## 유의사항
+
 ### 1) `inheritable=true` 남용 금지
+
 - `RequestContextFilter#setThreadContextInheritable(true)`는 thread pool과 결합되면 다른 요청으로 컨텍스트가 새는 위험이 있다.
 
 ### 2) 깊은 계층에서의 직접 호출 지양
+
 - 서비스/도메인 계층에서 `RequestContextHolder`를 직접 호출하면 테스트가 어려워지고 실행 모델 변경(비동기/배치)에 취약해진다.
 
 ### 3) API 선택 기준
+
 - `currentRequestAttributes()`: 컨텍스트가 반드시 있어야 하는 경계에서 사용 (없으면 즉시 실패)
 - `getRequestAttributes()`: optional한 조회가 필요한 구간에서 null-safe 처리
 
 ### 4) 테스트 전략
+
 - 단위/통합 테스트에서 `RequestContextHolder.resetRequestAttributes()`로 격리 보장
 - 요청 컨텍스트 없는 케이스(예외 발생)와 비동기 누락 케이스를 함께 검증
 
-## 참고 코드
-- 컨트롤러: `GET /study/request-context/{current|async|coroutine}`
-- 서비스:
-  - 현재 요청 조회
-  - async worker에서의 누락 확인
-  - coroutine 전환 시 누락 확인 + 명시 전달/`asContextElement` 비교
-
 ## 공식 문서
+
 - RequestContextHolder Javadoc: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/context/request/RequestContextHolder.html
 - RequestContextFilter Javadoc: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/RequestContextFilter.html
 - RequestContextListener Javadoc: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/context/request/RequestContextListener.html

--- a/dummy/2026-04-12_eventual-consistency-review-summary-practice.md
+++ b/dummy/2026-04-12_eventual-consistency-review-summary-practice.md
@@ -40,7 +40,120 @@ sequenceDiagram
   Projector->>SummaryRepo: save(summary)
 ```
 
-적용 코드:
+적용 코드는 크게 세 부분으로 나뉜다.
+
+### 1) 쓰기 모델: Review 애그리거트 저장 후 이벤트 발행
+
+`StudyReviewService`는 리뷰 쓰기 트랜잭션을 처리하고, 저장 직후 이벤트를 발행한다. 이 시점에 `ProductReviewSummary`를 직접 수정하지 않는 것이 포인트다.
+
+```kotlin
+@Service
+class StudyReviewService(
+    private val reviewRepository: ReviewRepository,
+    private val reviewEventPublisher: ReviewEventPublisher,
+) {
+    @Transactional
+    fun writeReview(command: WriteReviewCommand): Review {
+        val review = Review.create(
+            id = ReviewId.of(command.reviewId),
+            productId = ProductId.of(command.productId),
+            reviewerId = MemberId.of(command.reviewerId),
+            score = ReviewScore.of(command.score),
+            content = command.content,
+        )
+
+        return review.also {
+            reviewRepository.save(it)
+            reviewEventPublisher.publish(
+                ReviewWrittenEvent(
+                    reviewId = it.id,
+                    productId = it.productId,
+                    score = it.score.value,
+                    occurredAt = Instant.now(),
+                ),
+            )
+        }
+    }
+}
+```
+
+### 2) 비동기 전달: queue에 넣고 worker가 subscriber 호출
+
+학습용 구현에서는 `LinkedBlockingQueue`와 worker thread로 지연을 재현한다. 운영에서는 이 자리를 Kafka, RabbitMQ, SQS 같은 메시지 브로커로 바꿀 수 있다.
+
+```kotlin
+class InMemoryAsyncReviewEventPublisher(
+    private val processingDelayMillis: Long = 100,
+) : ReviewEventPublisher, AutoCloseable {
+    private val running = AtomicBoolean(true)
+    private val queue = LinkedBlockingQueue<ReviewEvent>()
+    private val subscribers = CopyOnWriteArrayList<ReviewEventSubscriber>()
+
+    private val worker = Thread {
+        while (running.get() || queue.isNotEmpty()) {
+            val event = queue.poll(200, TimeUnit.MILLISECONDS) ?: continue
+            Thread.sleep(processingDelayMillis)
+            subscribers.forEach { it.on(event) }
+        }
+    }.apply { start() }
+
+    override fun publish(event: ReviewEvent) {
+        queue.offer(event)
+    }
+
+    override fun subscribe(subscriber: ReviewEventSubscriber) {
+        subscribers.add(subscriber)
+    }
+}
+```
+
+### 3) 읽기 모델: 이벤트를 ProductReviewSummary에 투영
+
+Projector는 이벤트를 읽기 모델에 반영한다. `ReviewWrittenEvent`는 리뷰 수와 평균을 새로 반영하고, `ReviewEditedEvent`는 이전 점수와 새 점수의 차이를 반영한다.
+
+```kotlin
+class ProductReviewSummaryProjector(
+    private val summaryRepository: ProductReviewSummaryRepository,
+) : ReviewEventSubscriber {
+    override fun on(event: ReviewEvent) {
+        when (event) {
+            is ReviewWrittenEvent -> {
+                val current = summaryRepository.findByProductId(event.productId)
+                    ?: ProductReviewSummary.empty(event.productId)
+                summaryRepository.save(current.applyReviewWritten(event.score))
+            }
+
+            is ReviewEditedEvent -> {
+                val current = summaryRepository.findByProductId(event.productId)
+                    ?: ProductReviewSummary.empty(event.productId)
+                summaryRepository.save(current.applyReviewEdited(event.oldScore, event.newScore))
+            }
+        }
+    }
+}
+```
+
+테스트는 쓰기 직후 조회 모델이 비어 있을 수 있음을 먼저 확인하고, 이후 일정 시간 동안 projector 반영을 기다린다.
+
+```kotlin
+reviewService.writeReview(
+    WriteReviewCommand(
+        reviewId = "review-1",
+        productId = "product-1",
+        reviewerId = "member-1",
+        score = 5,
+        content = "excellent",
+    ),
+)
+
+summaryRepository.findByProductId(ProductId.of("product-1")) shouldBe null
+
+val afterWrite = awaitSummary(summaryRepository, "product-1") { summary ->
+    summary.reviewCount == 1 && summary.averageScore == 5.0
+}
+```
+
+정리하면 다음 코드가 서로 연결된다.
 
 - 이벤트 모델: `ReviewEvent`, `ReviewWrittenEvent`, `ReviewEditedEvent`
 - 퍼블리셔: `ReviewEventPublisher`, `InMemoryAsyncReviewEventPublisher`

--- a/dummy/2026-04-12_eventual-consistency-review-summary-practice.md
+++ b/dummy/2026-04-12_eventual-consistency-review-summary-practice.md
@@ -1,0 +1,61 @@
+# Eventual Consistency 실습: Review -> ProductReviewSummary
+
+## 요약
+
+이 실습은 애그리거트 경계를 유지하면서도 화면/조회 요구를 만족하기 위해
+eventual consistency를 적용하는 방법을 다룬다.
+
+- `Review`는 독립 애그리거트로 쓰기 트랜잭션을 처리한다.
+- 쓰기 직후 `ReviewEvent`를 발행한다.
+- 비동기 소비자가 `ProductReviewSummary` 리드모델을 갱신한다.
+- 따라서 쓰기 직후와 조회 결과 사이에 짧은 시차가 발생할 수 있다.
+
+## 사용법
+
+1. 리뷰 작성/수정은 `StudyReviewService`로 처리한다.
+2. `InMemoryAsyncReviewEventPublisher`가 이벤트를 비동기로 전달한다.
+3. `ProductReviewSummaryProjector`가 이벤트를 받아 요약 리드모델을 갱신한다.
+4. 조회는 `ProductReviewSummaryRepository`에서 읽는다.
+
+핵심 테스트:
+
+- `src/test/kotlin/com/vibewithcodex/study/ddd/review/EventualConsistencyReviewSummaryTest.kt`
+
+## 동작 방식
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant ReviewSvc as StudyReviewService
+  participant ReviewRepo as ReviewRepository
+  participant Publisher as AsyncReviewEventPublisher
+  participant Projector as ProductReviewSummaryProjector
+  participant SummaryRepo as ProductReviewSummaryRepository
+
+  Client->>ReviewSvc: writeReview/editReview
+  ReviewSvc->>ReviewRepo: save(review)
+  ReviewSvc->>Publisher: publish(ReviewEvent)
+  Note right of Publisher: 비동기 처리 (지연 가능)
+  Publisher->>Projector: on(event)
+  Projector->>SummaryRepo: save(summary)
+```
+
+적용 코드:
+
+- 이벤트 모델: `ReviewEvent`, `ReviewWrittenEvent`, `ReviewEditedEvent`
+- 퍼블리셔: `ReviewEventPublisher`, `InMemoryAsyncReviewEventPublisher`
+- 프로젝터: `ProductReviewSummaryProjector`
+- 리드모델: `ProductReviewSummary`
+
+## 응용
+
+- 실제 운영에서는 in-memory 퍼블리셔 대신 Kafka/RabbitMQ 같은 브로커로 교체할 수 있다.
+- 리드모델(`ProductReviewSummary`)은 캐시/검색 인덱스/별도 조회 DB로 확장할 수 있다.
+- 같은 방식으로 주문/결제/배송 상태 통합 조회 모델도 구성할 수 있다.
+
+## 유의사항
+
+- eventual consistency에서는 "즉시 일치"를 기대하면 안 된다.
+- 이벤트 중복/순서 역전/재처리 실패를 고려해 소비자를 멱등하게 설계해야 한다.
+- 트랜잭션은 여전히 "애그리거트 단위"로 작게 유지해야 한다.
+- 이 예제는 학습용이므로 outbox 패턴/재시도/데드레터까지는 생략했다.

--- a/dummy/2026-04-13_caffeine-local-cache-patterns.md
+++ b/dummy/2026-04-13_caffeine-local-cache-patterns.md
@@ -1,0 +1,140 @@
+# Caffeine Local Cache 활용 패턴 정리
+
+이 문서는 `com.vibewithcodex.study.cachetier` 패키지의 실습 코드와 함께 보는 짧은 가이드다. 목표는 Redis/DB 계층 설계까지 확장하기보다, **Caffeine 하나로 어떤 활용 패턴을 만들 수 있는지**를 선명하게 정리하는 것이다.
+
+---
+
+## 요약
+
+- Caffeine은 단순 Map 대체재가 아니라 TTL, size eviction, loader, refresh, stats를 제공하는 local cache다.
+- 처음 학습할 때는 `Cache-aside`, `LoadingCache`, `refreshAfterWrite`, `stats/invalidate` 네 가지로 나누어 보면 충분하다.
+- 실무에서는 캐시 전략보다 먼저 “데이터가 조금 stale해도 되는가”, “miss 시 누가 값을 읽어오는가”, “무효화는 누가 책임지는가”를 정해야 한다.
+
+---
+
+## 1) 실습 API
+
+```http
+POST /study/cachetier/data/product:100
+Content-Type: application/json
+
+{
+  "value": "apple",
+  "invalidateCaches": true
+}
+```
+
+```http
+GET /study/cachetier/cache-aside/product:100
+GET /study/cachetier/loading/product:100
+GET /study/cachetier/refresh/product:100
+POST /study/cachetier/cache-aside/product:100/invalidate
+GET /study/cachetier/cache-aside/stats
+```
+
+응답에서 볼 핵심 필드는 다음이다.
+
+| 필드 | 의미 |
+| --- | --- |
+| `pattern` | 어떤 Caffeine 활용 패턴인지 |
+| `source` | `LOCAL_CACHE`, `LOADER`, `MISS` 중 어디에서 값이 왔는지 |
+| `message` | 해당 요청에서 관찰할 포인트 |
+
+---
+
+## 2) Cache-aside
+
+```kotlin
+cache.getIfPresent(key)?.let { return it }
+val loaded = origin[key] ?: return null
+cache.put(key, loaded)
+return loaded
+```
+
+서비스 코드가 캐시 조회, 원천 조회, 캐시 적재를 직접 제어한다.
+
+| 장점 | 주의사항 |
+| --- | --- |
+| 흐름이 명시적이고 디버깅이 쉽다 | miss 처리와 중복 로딩 방지를 직접 설계해야 한다 |
+| 조건부 적재, 예외 처리, 응답 메시지 제어가 쉽다 | 여러 서비스에 흩어지면 코드가 반복될 수 있다 |
+
+추천 상황은 캐시 miss 시 처리 규칙이 도메인마다 다르거나, 응답에서 hit/miss 원인을 설명해야 하는 경우다.
+
+---
+
+## 3) LoadingCache
+
+```kotlin
+val cache = Caffeine.newBuilder()
+    .maximumSize(10_000)
+    .expireAfterWrite(Duration.ofSeconds(10))
+    .build<String, String> { key -> loadFromOrigin(key) }
+
+val value = cache.get(key)
+```
+
+Caffeine이 miss 시 loader를 자동 호출한다.
+
+| 장점 | 주의사항 |
+| --- | --- |
+| 서비스 코드가 간결해진다 | loader가 느리거나 실패할 때 영향 범위를 고려해야 한다 |
+| 같은 key의 중복 로딩을 줄이기 좋다 | null을 캐싱할 수 없으므로 missing value 정책이 필요하다 |
+
+추천 상황은 key를 넣으면 값을 읽는 규칙이 단순하고 일관적인 경우다.
+
+---
+
+## 4) refreshAfterWrite
+
+```kotlin
+val cache = Caffeine.newBuilder()
+    .refreshAfterWrite(Duration.ofSeconds(3))
+    .expireAfterWrite(Duration.ofSeconds(10))
+    .build<String, String> { key -> loadFromOrigin(key) }
+```
+
+`refreshAfterWrite`는 “정해진 시간이 지나면 바로 삭제”가 아니라, refresh 대상이 된 entry를 접근 시점에 다시 로드할 수 있게 한다. 기존 값을 최대한 유지하면서 갱신하려는 성격이라, latency를 낮추고 싶은 read-heavy 데이터에 어울린다.
+
+| 장점 | 주의사항 |
+| --- | --- |
+| 오래된 값을 즉시 버리지 않아 tail latency에 유리하다 | stale 값을 잠깐 허용할 수 있어야 한다 |
+| 주기적 재조회 데이터에 잘 맞는다 | loader 실패, refresh 지연을 관측해야 한다 |
+
+---
+
+## 5) stats/invalidate
+
+```kotlin
+cache.stats()
+cache.invalidate(key)
+```
+
+캐시는 넣는 것보다 관측하고 비우는 전략이 더 중요할 때가 많다.
+
+| 기능 | 확인할 것 |
+| --- | --- |
+| `recordStats()` | hit/miss/request/eviction을 볼 수 있다 |
+| `estimatedSize()` | 캐시가 얼마나 커졌는지 빠르게 확인한다 |
+| `invalidate(key)` | 특정 key의 stale 값을 제거한다 |
+| `invalidateAll()` | 배포/테스트/운영 대응 시 전체 초기화를 수행한다 |
+
+---
+
+## 선택 기준
+
+| 상황 | 우선 검토 |
+| --- | --- |
+| miss 처리 규칙이 도메인마다 다름 | Cache-aside |
+| key -> value 로딩 규칙이 단순함 | LoadingCache |
+| read-heavy이고 잠깐의 stale 허용 가능 | refreshAfterWrite |
+| 운영에서 hit ratio와 eviction 확인 필요 | recordStats |
+
+---
+
+## 유의사항
+
+- TTL은 정합성 정책이다. 무조건 길게 두면 stale 문제가 커진다.
+- `maximumSize` 없이 local cache를 운영하면 pod 메모리 사용량이 예측하기 어려워진다.
+- 캐시 key는 도메인, 식별자, 조건을 포함해 충돌을 피해야 한다.
+- loader는 빠르고 안정적이어야 하며, 실패 시 fallback 정책을 정해야 한다.
+- 다중 pod 정합성, Redis L2, 이벤트 기반 invalidation은 별도 주제로 분리해서 다루는 편이 이해하기 쉽다.

--- a/dummy/2026-04-13_caffeine-local-cache-patterns.md
+++ b/dummy/2026-04-13_caffeine-local-cache-patterns.md
@@ -1,6 +1,6 @@
 # Caffeine Local Cache 활용 패턴 정리
 
-이 문서는 `com.vibewithcodex.study.cachetier` 패키지의 실습 코드와 함께 보는 짧은 가이드다. 목표는 Redis/DB 계층 설계까지 확장하기보다, **Caffeine 하나로 어떤 활용 패턴을 만들 수 있는지**를 선명하게 정리하는 것이다.
+이 문서는 `com.vibewithcodex.study.cachetier` 패키지의 실습 코드와 함께 보는 짧은 가이드다. 목표는 Redis/DB 계층 설계까지 확장하기보다, **Caffeine 하나로 어떤 활용 패턴을 만들 수 있는지**를 코드 흐름 중심으로 정리하는 것이다.
 
 ---
 
@@ -12,24 +12,57 @@
 
 ---
 
-## 1) 실습 API
+## 1) 실습 코드 구조
 
-```http
-POST /study/cachetier/data/product:100
-Content-Type: application/json
+HTTP 호출 자체보다 중요한 것은 Controller가 어떤 서비스 메서드로 위임하고, 서비스가 Caffeine을 어디까지 직접 제어하는지다.
 
-{
-  "value": "apple",
-  "invalidateCaches": true
+```kotlin
+@RestController
+@RequestMapping("/study/cachetier")
+class StudyCacheTierController(
+    private val studyCacheTierService: StudyCacheTierService,
+) {
+    @GetMapping("/cache-aside/{key}")
+    fun getWithCacheAside(@PathVariable key: String) =
+        studyCacheTierService.getWithCacheAside(key)
+
+    @GetMapping("/loading/{key}")
+    fun getWithLoadingCache(@PathVariable key: String) =
+        studyCacheTierService.getWithLoadingCache(key)
+
+    @GetMapping("/refresh/{key}")
+    fun getWithRefreshAfterWrite(@PathVariable key: String) =
+        studyCacheTierService.getWithRefreshAfterWrite(key)
 }
 ```
 
-```http
-GET /study/cachetier/cache-aside/product:100
-GET /study/cachetier/loading/product:100
-GET /study/cachetier/refresh/product:100
-POST /study/cachetier/cache-aside/product:100/invalidate
-GET /study/cachetier/cache-aside/stats
+서비스는 origin 역할의 `ConcurrentHashMap`과 Caffeine 캐시 3개를 나란히 둔다. 같은 데이터를 여러 전략으로 관찰하기 위한 학습용 구조다.
+
+```kotlin
+class StudyCacheTierService(
+    private val properties: StudyCacheTierProperties,
+) {
+    private val originData = ConcurrentHashMap<String, String>()
+
+    private val cacheAsideCache: Cache<String, String> = Caffeine.newBuilder()
+        .expireAfterWrite(Duration.ofSeconds(properties.localTtlSeconds))
+        .maximumSize(properties.localMaximumSize)
+        .recordStats()
+        .build()
+
+    private val loadingCache: LoadingCache<String, String> = Caffeine.newBuilder()
+        .expireAfterWrite(Duration.ofSeconds(properties.localTtlSeconds))
+        .maximumSize(properties.localMaximumSize)
+        .recordStats()
+        .build { key -> loadForLoadingCache(key) }
+
+    private val refreshAfterWriteCache: LoadingCache<String, String> = Caffeine.newBuilder()
+        .refreshAfterWrite(Duration.ofSeconds(properties.refreshAfterWriteSeconds))
+        .expireAfterWrite(Duration.ofSeconds(properties.localTtlSeconds))
+        .maximumSize(properties.localMaximumSize)
+        .recordStats()
+        .build { key -> loadForRefreshCache(key) }
+}
 ```
 
 응답에서 볼 핵심 필드는 다음이다.
@@ -44,14 +77,40 @@ GET /study/cachetier/cache-aside/stats
 
 ## 2) Cache-aside
 
+Cache-aside는 서비스 코드가 캐시 조회, 원천 조회, 캐시 적재를 직접 제어한다.
+
 ```kotlin
-cache.getIfPresent(key)?.let { return it }
-val loaded = origin[key] ?: return null
-cache.put(key, loaded)
-return loaded
+fun getWithCacheAside(key: String): CacheLookupResponse {
+    cacheAsideCache.getIfPresent(key)?.let { cached ->
+        return CacheLookupResponse(
+            key = key,
+            value = cached,
+            pattern = CachePattern.CACHE_ASIDE,
+            source = CacheSource.LOCAL_CACHE,
+            message = "Cache-aside hit",
+        )
+    }
+
+    val loaded = originData[key] ?: return CacheLookupResponse(
+        key = key,
+        value = null,
+        pattern = CachePattern.CACHE_ASIDE,
+        source = CacheSource.MISS,
+        message = "Origin data does not exist",
+    )
+
+    cacheAsideCache.put(key, loaded)
+    return CacheLookupResponse(
+        key = key,
+        value = loaded,
+        pattern = CachePattern.CACHE_ASIDE,
+        source = CacheSource.LOADER,
+        message = "Loaded origin data and populated Caffeine",
+    )
+}
 ```
 
-서비스 코드가 캐시 조회, 원천 조회, 캐시 적재를 직접 제어한다.
+이 패턴에서는 “miss일 때 무엇을 할지”가 서비스 코드에 드러난다. 값이 없으면 `MISS`로 응답하고, 값이 있으면 Caffeine에 직접 `put`한다.
 
 | 장점 | 주의사항 |
 | --- | --- |
@@ -64,36 +123,75 @@ return loaded
 
 ## 3) LoadingCache
 
-```kotlin
-val cache = Caffeine.newBuilder()
-    .maximumSize(10_000)
-    .expireAfterWrite(Duration.ofSeconds(10))
-    .build<String, String> { key -> loadFromOrigin(key) }
+`LoadingCache`는 miss 시 Caffeine이 loader를 호출한다. 서비스는 `get(key)`만 호출하고, 값을 가져오는 규칙은 builder의 loader에 둔다.
 
-val value = cache.get(key)
+```kotlin
+private val loadingCache: LoadingCache<String, String> = Caffeine.newBuilder()
+    .maximumSize(properties.localMaximumSize)
+    .expireAfterWrite(Duration.ofSeconds(properties.localTtlSeconds))
+    .recordStats()
+    .build { key -> loadForLoadingCache(key) }
+
+fun getWithLoadingCache(key: String): CacheLookupResponse {
+    val before = loadingCache.getIfPresent(key)
+    val value = loadingCache.get(key)
+
+    return CacheLookupResponse(
+        key = key,
+        value = value,
+        pattern = CachePattern.LOADING_CACHE,
+        source = if (before == null) CacheSource.LOADER else CacheSource.LOCAL_CACHE,
+        message = if (before == null) "Loader called" else "Cached value returned",
+    )
+}
+
+private fun loadForLoadingCache(key: String): String {
+    return originData[key] ?: "generated:$key"
+}
 ```
 
-Caffeine이 miss 시 loader를 자동 호출한다.
+학습 코드에서는 origin에 값이 없을 때 `generated:$key`를 반환한다. 운영 코드라면 missing value를 예외로 볼지, null object로 볼지, fallback으로 볼지를 별도로 정해야 한다.
 
 | 장점 | 주의사항 |
 | --- | --- |
 | 서비스 코드가 간결해진다 | loader가 느리거나 실패할 때 영향 범위를 고려해야 한다 |
 | 같은 key의 중복 로딩을 줄이기 좋다 | null을 캐싱할 수 없으므로 missing value 정책이 필요하다 |
 
-추천 상황은 key를 넣으면 값을 읽는 규칙이 단순하고 일관적인 경우다.
-
 ---
 
 ## 4) refreshAfterWrite
 
+`refreshAfterWrite`는 “정해진 시간이 지나면 바로 삭제”가 아니라, refresh 대상이 된 entry를 접근 시점에 다시 로드할 수 있게 한다. 기존 값을 최대한 유지하면서 갱신하려는 성격이라, latency를 낮추고 싶은 read-heavy 데이터에 어울린다.
+
 ```kotlin
-val cache = Caffeine.newBuilder()
-    .refreshAfterWrite(Duration.ofSeconds(3))
-    .expireAfterWrite(Duration.ofSeconds(10))
-    .build<String, String> { key -> loadFromOrigin(key) }
+private val refreshAfterWriteCache: LoadingCache<String, String> = Caffeine.newBuilder()
+    .refreshAfterWrite(Duration.ofSeconds(properties.refreshAfterWriteSeconds))
+    .expireAfterWrite(Duration.ofSeconds(properties.localTtlSeconds))
+    .maximumSize(properties.localMaximumSize)
+    .recordStats()
+    .build { key -> loadForRefreshCache(key) }
+
+fun refreshNow(key: String): CacheMutationResponse {
+    val value = refreshAfterWriteCache.refresh(key).get()
+    return CacheMutationResponse(
+        key = key,
+        value = value,
+        message = "RefreshAfterWrite cache refreshed from origin data",
+    )
+}
 ```
 
-`refreshAfterWrite`는 “정해진 시간이 지나면 바로 삭제”가 아니라, refresh 대상이 된 entry를 접근 시점에 다시 로드할 수 있게 한다. 기존 값을 최대한 유지하면서 갱신하려는 성격이라, latency를 낮추고 싶은 read-heavy 데이터에 어울린다.
+테스트에서는 origin 값을 바꾼 뒤 캐시를 무효화하지 않아 stale 값을 관찰하고, 이후 refresh를 통해 새 값을 확인한다.
+
+```kotlin
+studyCacheTierService.putData("product:3", "old")
+studyCacheTierService.getWithRefreshAfterWrite("product:3").value shouldBe "old"
+
+studyCacheTierService.putData("product:3", "new", invalidateCaches = false)
+studyCacheTierService.getWithRefreshAfterWrite("product:3").value shouldBe "old"
+
+studyCacheTierService.refreshNow("product:3").value shouldBe "new"
+```
 
 | 장점 | 주의사항 |
 | --- | --- |
@@ -104,12 +202,29 @@ val cache = Caffeine.newBuilder()
 
 ## 5) stats/invalidate
 
-```kotlin
-cache.stats()
-cache.invalidate(key)
-```
-
 캐시는 넣는 것보다 관측하고 비우는 전략이 더 중요할 때가 많다.
+
+```kotlin
+fun invalidate(cacheName: String, key: String): CacheMutationResponse {
+    cacheByName(cacheName).invalidate(key)
+    return CacheMutationResponse(key = key, value = null, message = "Invalidated")
+}
+
+fun getStats(cacheName: String): CacheStatsResponse {
+    val cache = cacheByName(cacheName)
+    val stats = cache.stats()
+    return CacheStatsResponse(
+        cacheName = cacheName,
+        requestCount = stats.requestCount(),
+        hitCount = stats.hitCount(),
+        missCount = stats.missCount(),
+        hitRate = stats.hitRate(),
+        evictionCount = stats.evictionCount(),
+        estimatedSize = cache.estimatedSize(),
+        loaderCallCount = loaderCount(cacheName),
+    )
+}
+```
 
 | 기능 | 확인할 것 |
 | --- | --- |

--- a/infra/k8s/2026-03-24_k8s-local-cache-patterns.md
+++ b/infra/k8s/2026-03-24_k8s-local-cache-patterns.md
@@ -35,6 +35,22 @@ flowchart LR
 핵심은 "캐시가 파드 간 공유되지 않는다"는 점이다.
 따라서 L1만으로는 수평 확장 시 hit ratio가 구조적으로 낮아질 수 있다.
 
+학습 코드로 보면 각 파드마다 아래 객체들이 별도로 존재한다고 이해하면 된다. `originData`가 DB/Redis를 단순화한 저장소이고, `cacheAsideCache`가 JVM 내부 L1 캐시다.
+
+```kotlin
+class StudyCacheTierService {
+    private val originData = ConcurrentHashMap<String, String>()
+
+    private val cacheAsideCache: Cache<String, String> = Caffeine.newBuilder()
+        .expireAfterWrite(Duration.ofSeconds(localTtlSeconds))
+        .maximumSize(localMaximumSize)
+        .recordStats()
+        .build()
+}
+```
+
+파드가 100개라면 이 `cacheAsideCache`도 100개다. A 파드의 cache hit는 B 파드의 hit로 이어지지 않는다.
+
 ---
 
 ## 2) 운영 패턴 3가지
@@ -107,6 +123,21 @@ Pattern C는 stale 억제에 강하지만, 이벤트 유실/지연/중복 처리
 ---
 
 ## 4) 운영 체크리스트
+
+쓰기 경로에서는 최소한 해당 파드의 L1을 비우는 규칙이 필요하다. 학습 코드에서는 origin을 갱신한 뒤 세 캐시를 모두 invalidate한다.
+
+```kotlin
+fun putData(key: String, value: String, invalidateCaches: Boolean = true) {
+    originData[key] = value
+    if (invalidateCaches) {
+        cacheAsideCache.invalidate(key)
+        loadingCache.invalidate(key)
+        refreshAfterWriteCache.invalidate(key)
+    }
+}
+```
+
+K8s에서는 이 코드가 “현재 요청을 처리한 파드의 L1만 비운다”는 점이 중요하다. 다른 파드의 L1까지 비우려면 Redis Pub/Sub, Kafka, Spring Cloud Bus 같은 무효화 전파가 추가로 필요하다.
 
 | 체크 항목 | 질문 | 권장 기준 |
 | --- | --- | --- |

--- a/infra/k8s/2026-03-24_k8s-local-cache-patterns.md
+++ b/infra/k8s/2026-03-24_k8s-local-cache-patterns.md
@@ -1,0 +1,163 @@
+# K8s 다중 파드에서 Local Cache 운영 패턴 가이드
+
+이 문서는 기존 cachetier 학습 문서와 별개로, **다중 파드(K8s) 운영 환경**에서 Local Cache를 어떻게 써야 하는지 의사결정 관점으로 정리한다.
+
+---
+
+## TL;DR
+- 파드가 많아질수록 Local Cache는 파드별로 분산되어 hit ratio가 떨어지기 쉽다.
+- 실무 기본값은 `L1(Local) + L2(Redis)` 구조다.
+- 일관성이 중요해지면 무효화 이벤트 전파(Pub/Sub 등)까지 포함한 구조로 확장한다.
+- 캐시 전략은 "성능 최적화"보다 "일관성 요구 + 운영 복잡도 + 장애 대응"을 함께 보고 결정한다.
+
+---
+
+## 1) 문제 정의: 왜 100개 파드에서 Local Cache 효율이 떨어지나
+
+### 1-1. 현상
+- 첫 요청이 A 파드에 들어가면 A 파드의 Local Cache만 warm-up된다.
+- 동일 키라도 다음 요청이 B/C/D 파드로 가면 각 파드에서 다시 miss가 발생한다.
+- 파드 수가 많아질수록 "파드별 독립 캐시" 특성 때문에 전체 hit ratio가 낮아진다.
+
+### 1-2. 구조 다이어그램
+
+```mermaid
+flowchart LR
+    U[Client Requests] --> LB[Load Balancer]
+    LB --> P1[Pod A - L1 Cache]
+    LB --> P2[Pod B - L1 Cache]
+    LB --> P3[Pod C - L1 Cache]
+    P1 --> DB[(DB/Origin)]
+    P2 --> DB
+    P3 --> DB
+```
+
+핵심은 "캐시가 파드 간 공유되지 않는다"는 점이다.
+따라서 L1만으로는 수평 확장 시 hit ratio가 구조적으로 낮아질 수 있다.
+
+---
+
+## 2) 운영 패턴 3가지
+
+### 2-1. 패턴 비교표
+
+| 패턴 | 구조 | 장점 | 단점 | 추천 상황 |
+| --- | --- | --- | --- | --- |
+| Pattern A: L1 only | 파드별 Local Cache만 사용 | 응답 지연 최소, 구조 단순 | 파드 수 증가 시 hit ratio 저하, 일관성 약함 | 소규모 트래픽, 일관성 민감도 낮음 |
+| Pattern B: L1 + L2 | Local miss 시 Redis 조회 후 L1 적재 | 공유 캐시로 miss 비용 완화, 실무 기본형 | L1/L2 TTL 설계 필요, Redis 의존성 증가 | 대부분의 일반 웹 서비스 |
+| Pattern C: L1 + L2 + 무효화 전파 | L2 업데이트 시 이벤트로 각 L1 무효화 | stale 완화, 데이터 일관성 개선 | 운영 복잡도 상승(Pub/Sub, 재시도, 순서) | 정합성 요구가 높은 도메인 |
+
+### 2-2. 운영 난이도/효과 비교표
+
+| 항목 | Pattern A | Pattern B | Pattern C |
+| --- | --- | --- | --- |
+| 구현 난이도 | 낮음 | 중간 | 높음 |
+| 운영 난이도 | 낮음 | 중간 | 높음 |
+| 평균 응답속도 | 빠름 | 빠름 | 빠름 |
+| 수평 확장 대응 | 낮음 | 중간~높음 | 높음 |
+| 데이터 일관성 | 낮음 | 중간 | 높음 |
+| 장애 대응 복잡도 | 낮음 | 중간 | 높음 |
+
+---
+
+## 3) 패턴별 흐름 다이어그램
+
+### 3-1. Pattern B (L1 + L2) 권장 기본형
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant P as Pod (L1)
+    participant R as Redis (L2)
+    participant O as Origin
+
+    C->>P: GET key
+    P->>P: L1 조회
+    alt L1 hit
+        P-->>C: 값 반환
+    else L1 miss
+        P->>R: L2 조회
+        alt L2 hit
+            P->>P: L1 적재
+            P-->>C: 값 반환
+        else L2 miss
+            P->>O: 원본 조회
+            O-->>P: 값 반환
+            P->>R: L2 적재
+            P->>P: L1 적재
+            P-->>C: 값 반환
+        end
+    end
+```
+
+### 3-2. Pattern C (무효화 전파 포함)
+
+```mermaid
+flowchart TD
+    A[Write/Update] --> B[Origin Update]
+    B --> C[Redis Update]
+    C --> D[Invalidate Event Publish]
+    D --> E[Pod A L1 Invalidate]
+    D --> F[Pod B L1 Invalidate]
+    D --> G[Pod C L1 Invalidate]
+```
+
+Pattern C는 stale 억제에 강하지만, 이벤트 유실/지연/중복 처리 규칙을 함께 설계해야 한다.
+
+---
+
+## 4) 운영 체크리스트
+
+| 체크 항목 | 질문 | 권장 기준 |
+| --- | --- | --- |
+| TTL 계층 설계 | L1 TTL과 L2 TTL이 역할별로 분리되어 있는가? | L1은 짧게(마이크로캐시), L2는 상대적으로 길게 |
+| 키 설계 | 키 단위로 데이터 소유 범위가 명확한가? | 버전/테넌트/도메인 구분 키 포함 |
+| Stampede 완화 | same-key 동시 miss 보호가 있는가? | single-flight, jitter TTL, preload 검토 |
+| 관측성 | hit/miss/eviction/load latency를 보는가? | 배포 전후 지표 비교 필수 |
+| 무효화 정책 | 쓰기 시 invalidate 경로가 명확한가? | 최소한 write-path invalidate 규칙 문서화 |
+| Warm-up | 기동 직후 cold start를 완화하는가? | hot key pre-warm 또는 점진 warm-up |
+
+---
+
+## 5) 증상 기반 대응표
+
+| 증상 | 가능한 원인 | 먼저 볼 지표 | 1차 대응 |
+| --- | --- | --- | --- |
+| 파드 늘린 뒤 hit ratio 급락 | L1 분산 심화 | 파드별 hit/miss, key 분포 | Pattern B(L1+L2) 전환 또는 L1 TTL 단축 |
+| Redis QPS 급증 | 동시 miss 폭주, stampede | Redis cmd/sec, miss burst | single-flight, TTL jitter, hot key 분리 |
+| stale 데이터 노출 증가 | 무효화 지연/누락 | stale 비율, 이벤트 처리 지연 | write invalidate 강화, Pattern C 검토 |
+| 배포 직후 지연 스파이크 | cold start + warm-up 부재 | p95/p99, startup hit ratio | pre-warm, rolling 시 warm-up 단계 추가 |
+| 특정 키만 과부하 | hot key 편중 | key별 트래픽 상위 N | key 분리, 별도 TTL/보호 정책 적용 |
+
+---
+
+## 6) 이후 대안 로드맵
+
+### 6-1. 단계별 실행 계획
+
+| 단계 | 기간 예시 | 목표 | 주요 작업 | 성공 지표 |
+| --- | --- | --- | --- | --- |
+| 단기 | 2~4주 | 현재 구조 안정화 | L1+L2 정착, TTL 재정의, 관측성 대시보드, stampede 완화 | hit ratio 개선, Redis burst 감소 |
+| 중기 | 1~2분기 | 일관성/효율 개선 | 키 기반 라우팅 검토, 무효화 이벤트 전파 도입, hot key 최적화 | stale 감소, p95 안정화 |
+| 장기 | 분기+ | 아키텍처 단순화/고도화 | 도메인별 캐시 전략 분리, 일부 L1 축소 또는 Redis 중심화 | 운영 복잡도 대비 성능 효율 최적화 |
+
+### 6-2. 다음 단계로 넘어가는 신호
+
+| 현재 상태 | 전환 신호 | 다음 권장 단계 |
+| --- | --- | --- |
+| Pattern A 사용 중 | 파드 증가 후 hit ratio 하락이 반복 | Pattern B 전환 |
+| Pattern B 사용 중 | stale 이슈가 운영 이슈로 반복 | Pattern C 도입 검토 |
+| Pattern C 사용 중 | 운영 복잡도 과다, 장애 대응 부담 증가 | 도메인별 전략 분리/단순화 |
+
+---
+
+## 7) 결론
+- 100개 파드 환경에서는 Local Cache 단독 전략이 구조적으로 불리하다.
+- 운영 기본형은 Pattern B(`L1 + L2`)이고, 정합성 요구가 높을 때 Pattern C로 확장하는 흐름이 안전하다.
+- "정답"보다 중요한 것은, 서비스의 정합성 요구와 운영 복잡도 허용치를 기준으로 단계적으로 진화시키는 것이다.
+
+---
+
+## 참고 연결
+- [Caffeine Local Cache 딥다이브](../../dummy/2026-03-22_caffeine-local-cache-deep-dive.md)
+- [Caffeine 내부구조 심화](../../dummy/2026-03-22_caffeine-local-cache-internals-deep-dive.md)

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -57,6 +57,7 @@
 * [backup & restore : resources, etcdctl](2022-08-15_know-backup-restore.md)
     * [practice01](2022-08-15_know-backup-restore-practice01.md)
 * [security](2022-08-27_know-security.md)
+* [local cache patterns : 다중 파드에서 로컬 캐시 운영 패턴](2026-03-24_k8s-local-cache-patterns.md)
 
 ## CKA 참고자료
 * [CKA udemy 강의](https://www.udemy.com/course/certified-kubernetes-administrator-with-practice-tests/)


### PR DESCRIPTION
## 변경 배경

- vibe-with-codex 저장소의 study 문서를 software-zero-to-all 학습 레포로 이관합니다.
- 문서 성격에 맞춰 dummy, development, infra/k8s 디렉터리에 분류했습니다.
- 코드베이스 기반 설명이 빠진 부분은 학습 레포에서 바로 읽히도록 핵심 Kotlin 코드블럭과 다이어그램 설명을 보강했습니다.

## 주요 변경 사항

- Caffeine, RequestContextHolder, Eventual Consistency 학습 문서 추가
- DDD 계층 구조와 DIP 실습 문서 추가
- K8s 다중 파드 Local Cache 운영 패턴 문서 추가
- README 및 infra/k8s README 인덱스 갱신
- HTTP/CLI 호출 중심 설명을 실제 Controller/Service/Test 코드 흐름 중심으로 보강
- RequestContextHolder 비동기/코루틴 전환 흐름 다이어그램 추가

## 확인한 내용

- git diff --check
- 이관 문서 내 http fenced block 제거 확인
- 상대 링크 파일 존재 확인